### PR TITLE
(hironx_ros_bridge) Remove obsolete build_depend on hrpsys_ros_bridge.

### DIFF
--- a/hironx_ros_bridge/catkin.cmake
+++ b/hironx_ros_bridge/catkin.cmake
@@ -1,11 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(hironx_ros_bridge)
 
-find_package(catkin REQUIRED COMPONENTS hrpsys_ros_bridge)
-
 catkin_package(
     DEPENDS # TODO
-    CATKIN-DEPENDS hrpsys_ros_bridge #
     INCLUDE_DIRS # TODO include
     LIBRARIES # TODO
 )

--- a/hironx_ros_bridge/package.xml
+++ b/hironx_ros_bridge/package.xml
@@ -15,7 +15,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>hrpsys_ros_bridge</build_depend>
   <build_depend>unzip</build_depend>
 
   <run_depend>hrpsys_ros_bridge</run_depend>


### PR DESCRIPTION
There might be non-apparent reason, but it seems it doesn't build_depend on hrpsys_ros_bridge.
