### PR TITLE
update .travis, matrix check with groovy/hydro and deb/src, also check i...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script: # Use this to prepare your build for testing e.g. copy database c
   - source /opt/ros/$ROS_DISTRO/setup.bash
 script: # All commands must exit with code 0 on success. Anything else is considered failure.
   - find -L . \! -path "*/.*" -type f | xargs egrep -i "(hoge|fuga)" ; if [ $? == 0 ]; then exit 1; fi
-  - catkin_make
+  - catkin_make -j8 -l8
   - catkin_make test
   - catkin_make install
 after_failure:


### PR DESCRIPTION
travis uses 32+ cpu machine and it some times kill gcc as follows, this we need to pass j8,l8 option to set limit for parallel compilation.

```
g++: internal compiler error: Killed (program cc1plus)
Please submit a full bug report,
with preprocessed source if appropriate.
See <file:///usr/share/doc/gcc-4.6/README.Bugs> for instructions.
```
