### PR TITLE
set groovy/catkin/deb to allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
   allow_failures:
     - env: ROS_DISTRO=groovy ROSWS=rosws  BUILDER=rosbuild  USE_DEB=true
     - env: ROS_DISTRO=groovy ROSWS=rosws  BUILDER=rosbuild  USE_DEB=false
+    - env: ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin    USE_DEB=true
 notifications:
   email:
     recipients:


### PR DESCRIPTION
set groovy/catkin/deb to allow_failures

since ros-goorvy-hrpsys-ros-bridge is not compiled on jenkins.ros.org
http://jenkins.ros.org/job/ros-groovy-hrpsys-ros-bridge_binarydeb_oneiric_amd64/
due to https://github.com/ros/dynamic_reconfigure/issues/29
