### PR TITLE
(sys-check) add debug print for iob checker binary

### DIFF
--- a/hironx_ros_bridge/robot/check/create-hrpiob-check.py
+++ b/hironx_ros_bridge/robot/check/create-hrpiob-check.py
@@ -39,6 +39,7 @@ def create_check_hrpiob_iob():
     try:
         print 0
         print subprocess.check_call(command, shell=True)
+        print subprocess.check_call(exename, shell=True)
         # convert exe to base64ascii
         f_exe = open(exename, 'r');
         f_txt = open('hrpiob_check_bin.py','w')

--- a/hironx_ros_bridge/robot/check/hrpiob_check.py
+++ b/hironx_ros_bridge/robot/check/hrpiob_check.py
@@ -14,8 +14,9 @@ def hrpiob_iob():
     st = os.stat(bin_name)
     os.chmod(bin_name, st.st_mode | stat.S_IEXEC)
 
+    subprocess.call("ldd %s" % (bin_name), shell=True)
     try:
-        if subprocess.check_call(bin_name, shell=True) == 0: 
+        if subprocess.check_call(bin_name, shell=True) == 0:
             raise Exception("%s exit with 0"%(bin_name))
     except Exception, e:
         ret = False


### PR DESCRIPTION
This works for the purpose stably on qnx.
