### PR TITLE
(test-hironx-ros-bridge.test) Add omniNames script to start it on ros buildfarm (see https://github.com/start-jsk/rtmros_common/issues/416#issuecomment-46846623)

### DIFF
--- a/hironx_ros_bridge/test/test-hironx-ros-bridge.test
+++ b/hironx_ros_bridge/test/test-hironx-ros-bridge.test
@@ -1,6 +1,10 @@
 <launch>
   <arg name="corbaport" default="2809" />
   <arg name="GUI" default="false" />
+  
+  <!-- See https://github.com/start-jsk/rtmros_common/issues/416#issuecomment-46846623 -->
+  <node name="start_omninames" pkg="rtmbuild" type="start_omninames.sh" args="$(arg corbaport)" />
+  
   <include file="$(find hironx_ros_bridge)/launch/hironx_ros_bridge_simulation.launch" >
     <arg name="GUI" value="$(arg GUI)" />
     <arg name="corbaport" value="$(arg corbaport)" />


### PR DESCRIPTION
[pre-release test on ros buildfarm (using devel) is failing](http://jenkins.ros.org/job/prerelease-hydro-rtmros_hironx/ARCH_PARAM=amd64,UBUNTU_PARAM=precise,label=prerelease/6/consoleFull) and [missing omniNames script](https://github.com/start-jsk/rtmros_common/issues/416#issuecomment-46846623) in one of `.test` files should be one reason. 

Another possible cause may lie here (below); this doesn't happen on my local machine. But I want to see if this still happens after this PReq is merged:

```
[ROSTEST]-----------------------------------------------------------------------
:
[hironx_ros_bridge.rosunit-test_hironx/testSetTargetPoseBothArm][passed]
[hironx_ros_bridge.rosunit-test_hironx/test_fullbody_setJointAngles_Clear][passed]
[hironx_ros_bridge.rosunit-test_hironx/test_fullbody_setJointAngles_NoWait][passed]
[hironx_ros_bridge.rosunit-test_hironx/test_fullbody_setJointAngles_Wait][passed]
[hironx_ros_bridge.rosunit-test_hironx/test_fullbody_setJointAngles_minus][FAILURE]
File "/usr/lib/python2.7/unittest/case.py", line 327, in run
    testMethod()
  File "/tmp/test_repositories/src_repository/rtmros_hironx/hironx_ros_bridge/test/test_hironx.py", line 346, in test_fullbody_setJointAngles_minus
    self.check_log_data(data, 6, 7.19, -140, -120.0, acc_thre = 1.0)
  File "/tmp/test_repositories/src_repository/rtmros_hironx/hironx_ros_bridge/test/test_hironx.py", line 134, in check_log_data
    self.assertTrue(abs(_max_data - max_data[0]) < max_data[1])
  File "/tmp/test_repositories/src_repository/rtmros_hironx/hironx_ros_bridge/test/test_hironx.py", line 358, in assertTrue
    assert(a)
--------------------------------------------------------------------------------

[hironx_ros_bridge.rosunit-test_hironx/test_goInitial][passed]
[hironx_ros_bridge.rosunit-test_hironx/test_rarm_setJointAnglesOfGroup_Override_Acceleration][passed]
[hironx_ros_bridge.rosunit-test_hironx/test_rarm_setJointAnglesOfGroup_minus][passed]
[hironx_ros_bridge.rosunit-test_hironx/test_rarm_setJointAngles_Clear][passed]
[hironx_ros_bridge.rosunit-test_hironx/test_rarm_setJointAngles_NoWait][passed]
[hironx_ros_bridge.rosunit-test_hironx/test_rarm_setJointAngles_Wait][passed]
[hironx_ros_bridge.rosunit-test_hironx_ik/test_ik_left][passed]
[hironx_ros_bridge.rosunit-test_hironx_ik/test_ik_right][passed]
[hironx_ros_bridge.rosunit-test_hironx_ik/test_set_target_pose][passed]

SUMMARY
[1;31m * RESULT: FAIL[0m
 * TESTS: 14
 * ERRORS: 0
[1;31m * FAILURES: 1[0m
:
```
