### PR TITLE
(robot-system-check.sh) Correct path to run binary inside qnx

### DIFF
--- a/hironx_ros_bridge/robot/robot-system-check.sh
+++ b/hironx_ros_bridge/robot/robot-system-check.sh
@@ -27,7 +27,7 @@ commands="
   . ~/.profile;
   env;
   ls -al /tmp/$TMPDIR/robot-system-check-base;
-  tmp/$TMPDIR/robot-system-check-base;
+  /tmp/$TMPDIR/robot-system-check-base;
   rm -fr /tmp/$TMPDIR
 "
 


### PR DESCRIPTION
Fix the following error:

```
hironx_ros_bridge/robot$ ./robot-system-check.sh nextage tork
:
-rwxr-xr-x  1 tork      users       8878220 Jul 10 09:25 /tmp/tmp.6276/robot-system-check-base
sh: tmp/tmp.6276/robot-system-check-base: cannot execute - No such file or directory
```
