### PR TITLE
(acceptancetest_hironx.py) Add tasks written in ROS. Add ROS client.

### DIFF
--- a/hironx_ros_bridge/package.xml
+++ b/hironx_ros_bridge/package.xml
@@ -24,12 +24,15 @@
   <build_depend>unzip</build_depend>
   <build_depend>gnuplot</build_depend>
 
+  <run_depend>actionlib</run_depend>
+  <run_depend>gnuplot</run_depend>
   <run_depend version_gte="315.1.8">hrpsys</run_depend> <!-- See https://github.com/tork-a/rtmros_nextage/issues/51 -->
   <run_depend>hrpsys_ros_bridge</run_depend>
+  <run_depend>pr2_controllers_msgs</run_depend>
   <run_depend>rosbash</run_depend>
+  <run_depend>rospy</run_depend>
   <run_depend>roslang</run_depend>
-
-  <run_depend>gnuplot</run_depend>
+  <run_depend>trajectory_msgs</run_depend>
   <!-- <test_depend>hrpsys_ros_bridge</test_depend> -->
 
   <export>

--- a/hironx_ros_bridge/scripts/acceptancetest_hironx.py
+++ b/hironx_ros_bridge/scripts/acceptancetest_hironx.py
@@ -88,11 +88,22 @@ class AcceptanceTest_Hiro():
     _DURATON_TOTAL_SMALLINCREMENT = 30  # Second.
 
     def __init__(self, rtm_robotname='HiroNX(Robot)0', url=''):
+        '''
+        Initiate both ROS and RTM robot clients, keep them public so that they
+        are callable from script. e.g. On ipython,
+
+                In [1]: acceptance.ros.go_init()
+                In [2]: acceptance.rtm.goOffPose()
+        '''
         self._rtm_robotname = rtm_robotname
         self._rtm_url = url
 
-        self._acceptance_ros_client = None
-        self._acceptance_rtm_client = None
+        # Init RTM and ROS client.
+        self.ros = ROS_Client()
+        self._acceptance_ros_client = AcceptanceTestROS(self.ros)
+        self.rtm = HIRONX()
+        self.rtm.init(robotname=self._rtm_robotname, url=self._rtm_url)
+        self._acceptance_rtm_client = AcceptanceTestRTM(self.rtm)
 
     def _wait_input(self, do_wait_input=False):
         '''
@@ -107,10 +118,6 @@ class AcceptanceTest_Hiro():
         @param do_wait_input: If True, the user will be asked to hit any key
                               before each task to proceed.
         '''
-        if not self._acceptance_rtm_client:
-            _rtm_client = HIRONX()
-            _rtm_client.init(robotname=self._rtm_robotname, url=self._rtm_url)
-            self._acceptance_rtm_client = AcceptanceTestRTM(_rtm_client)
         self._run_tests(self._acceptance_rtm_client, do_wait_input)
 
     def run_tests_ros(self, do_wait_input=False):
@@ -120,8 +127,6 @@ class AcceptanceTest_Hiro():
         @param do_wait_input: If True, the user will be asked to hit any key
                               before each task to proceed.
         '''
-        if not self._acceptance_ros_client:
-            self._acceptance_ros_client = AcceptanceTestROS(ROS_Client())
         self._run_tests(self._acceptance_ros_client, do_wait_input)
 
     def _run_tests(self, test_client, do_wait_input=False):

--- a/hironx_ros_bridge/scripts/acceptancetest_hironx.py
+++ b/hironx_ros_bridge/scripts/acceptancetest_hironx.py
@@ -302,4 +302,4 @@ if __name__ == '__main__':
     if len(unknown) >= 2:
         args.robot = unknown[0]
         args.modelfile = unknown[1]
-    acceptance_test = AcceptanceTest_Hiro()
+    acceptance = AcceptanceTest_Hiro()

--- a/hironx_ros_bridge/setup.py
+++ b/hironx_ros_bridge/setup.py
@@ -5,7 +5,7 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml
 setup_args = generate_distutils_setup(
-    packages=['hironx_ros_bridge'],
+    packages=['hironx_ros_bridge', 'hironx_ros_bridge.testutil'],
     package_dir={'': 'src'})
 
 setup(**setup_args)

--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
@@ -37,19 +37,15 @@ import math
 import numpy
 import os
 import time
-import socket
-import sys
 
 import roslib; roslib.load_manifest("hrpsys")
 from hrpsys.hrpsys_config import *
 import OpenHRP
 import OpenRTM_aist
 import OpenRTM_aist.RTM_IDL
-import rospy
 import rtm
 from waitInput import waitInputConfirm, waitInputSelect
 
-from hironx_ros_bridge.ros_client import ROS_Client
 
 SWITCH_ON = OpenHRP.RobotHardwareService.SWITCH_ON
 SWITCH_OFF = OpenHRP.RobotHardwareService.SWITCH_OFF
@@ -118,9 +114,6 @@ class HIRONX(HrpsysConfigurator):
         '''
         HrpsysConfigurator.init(self, robotname=robotname, url=url)
         self.setSelfGroups()
-
-        joint_group_names = [groupname for groupname, joints in self.Groups]
-        self.ros = ROS_Client(joint_group_names)
 
     def goOffPose(self, tm=7):
         '''

--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
@@ -45,8 +45,11 @@ from hrpsys.hrpsys_config import *
 import OpenHRP
 import OpenRTM_aist
 import OpenRTM_aist.RTM_IDL
+import rospy
 import rtm
 from waitInput import waitInputConfirm, waitInputSelect
+
+from hironx_ros_bridge.ros_client import ROS_Client
 
 SWITCH_ON = OpenHRP.RobotHardwareService.SWITCH_ON
 SWITCH_OFF = OpenHRP.RobotHardwareService.SWITCH_OFF
@@ -115,6 +118,9 @@ class HIRONX(HrpsysConfigurator):
         '''
         HrpsysConfigurator.init(self, robotname=robotname, url=url)
         self.setSelfGroups()
+
+        joint_group_names = [groupname for groupname, joints in self.Groups]
+        self.ros = ROS_Client(joint_group_names)
 
     def goOffPose(self, tm=7):
         '''

--- a/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py
@@ -1,0 +1,220 @@
+## -*- coding: utf-8 -*-
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2014, Tokyo Opensource Robotics Kyokai Association (TORK)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Tokyo Opensource Robotics Kyokai Association. nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import math
+
+import actionlib
+import pr2_controllers_msgs
+from pr2_controllers_msgs.msg import JointTrajectoryAction
+from pr2_controllers_msgs.msg import JointTrajectoryGoal
+import rospy
+from trajectory_msgs.msg import JointTrajectoryPoint
+
+_MSG_ASK_ISSUEREPORT = 'Your report to ' + \
+                       'https://github.com/start-jsk/rtmros_hironx/issues ' + \
+                       'about the issue you are seeing is appreciated.'
+
+
+class ROS_Client(object):
+    '''
+    This class:
+
+    - holds methods that are specific to Kawada Industries' dual-arm
+    robot called Hiro, via ROS.
+    - As of July 2014, this class is only intended to be used through HIRONX
+      class.
+    '''
+
+    #TODO: Address the following concern.
+    # This duplicates "Group" definition in HIRONX, which is bad.
+    # Need to consider consolidating the definition either in hironx_ros_bridge
+    # or somewhere in the upstream, e.g.:
+    # https://github.com/fkanehiro/hrpsys-base/pull/253
+    _GR_TORSO = 'torso'  # Default values are set.
+    _GR_HEAD = 'head'
+    _GR_LARM = 'larm'
+    _GR_RARM = 'rarm'
+
+    def __init__(self, jointgroups=None):
+        '''
+        @type jointgroups: [str]
+        '''
+        rospy.init_node('hironx_ros_client', anonymous=True)
+        if jointgroups:
+            self._set_groupnames(jointgroups)
+
+        self._aclient_larm = actionlib.SimpleActionClient(
+             '/larm_controller/joint_trajectory_action', JointTrajectoryAction)
+        self._aclient_larm.wait_for_server()
+        self._goal_larm = JointTrajectoryGoal()
+        self._goal_larm.trajectory.joint_names.append("LARM_JOINT0")
+        self._goal_larm.trajectory.joint_names.append("LARM_JOINT1")
+        self._goal_larm.trajectory.joint_names.append("LARM_JOINT2")
+        self._goal_larm.trajectory.joint_names.append("LARM_JOINT3")
+        self._goal_larm.trajectory.joint_names.append("LARM_JOINT4")
+        self._goal_larm.trajectory.joint_names.append("LARM_JOINT5")
+
+        self._aclient_rarm = actionlib.SimpleActionClient(
+             '/rarm_controller/joint_trajectory_action', JointTrajectoryAction)
+        self._aclient_rarm.wait_for_server()
+        self._goal_rarm = JointTrajectoryGoal()
+        self._goal_rarm.trajectory.joint_names.append("RARM_JOINT0")
+        self._goal_rarm.trajectory.joint_names.append("RARM_JOINT1")
+        self._goal_rarm.trajectory.joint_names.append("RARM_JOINT2")
+        self._goal_rarm.trajectory.joint_names.append("RARM_JOINT3")
+        self._goal_rarm.trajectory.joint_names.append("RARM_JOINT4")
+        self._goal_rarm.trajectory.joint_names.append("RARM_JOINT5")
+
+        self._aclient_head = actionlib.SimpleActionClient(
+             '/head_controller/joint_trajectory_action', JointTrajectoryAction)
+        self._aclient_head.wait_for_server()
+        self._goal_head = JointTrajectoryGoal()
+        self._goal_head.trajectory.joint_names.append('HEAD_JOINT0')
+        self._goal_head.trajectory.joint_names.append('HEAD_JOINT1')
+
+        self._aclient_torso = actionlib.SimpleActionClient(
+            '/torso_controller/joint_trajectory_action', JointTrajectoryAction)
+        self._aclient_torso.wait_for_server()
+        self._goal_torso = JointTrajectoryGoal()
+        self._goal_torso.trajectory.joint_names.append('CHEST_JOINT0')
+
+        rospy.logdebug('Joint names; ' +
+                      'Torso: {}\n\tHead: {}\n\tL-Arm: {}\n\tR-Arm: {}'.format(
+                                    self._goal_torso.trajectory.joint_names,
+                                    self._goal_head.trajectory.joint_names,
+                                    self._goal_larm.trajectory.joint_names,
+                                    self._goal_rarm.trajectory.joint_names))
+
+    def _set_groupnames(self, groupnames):
+        '''
+        @type groupnames: [str]
+        @param groupnames: List of the joint group names. Assumes to be in the
+                           following order:
+                               torso, head, right arm, left arm.
+                           This current setting is derived from the order of
+                           Groups argument in HIRONX class. If other groups
+                           need to be defined in the future, this method may
+                           need to be modified.
+        '''
+        rospy.loginfo('_set_groupnames; groupnames={}'.format(groupnames))
+        self._GR_TORSO = groupnames[0]
+        self._GR_HEAD = groupnames[1]
+        self._GR_RARM = groupnames[2]
+        self._GR_LARM = groupnames[3]
+
+    def go_init(self):
+        '''
+        Init positions are taken from HIRONX.
+        TODO: Need to add factory position too that's so convenient when
+              working with the manufacturer.
+        '''
+        rospy.loginfo('*** go_init begins ***')
+        TASK_DURATION = 5.0
+        POSITIONS_TORSO_DEG = [0.0]
+        self.set_joint_angles_deg(self._GR_TORSO, POSITIONS_TORSO_DEG, TASK_DURATION)
+        POSITIONS_HEAD_DEG = [0.0, 0.0]
+        self.set_joint_angles_deg(self._GR_HEAD, POSITIONS_HEAD_DEG, TASK_DURATION)
+        POSITIONS_LARM_DEG = [0.6, 0, -100, -15.2, 9.4, -3.2]
+        self.set_joint_angles_deg(self._GR_LARM, POSITIONS_LARM_DEG, TASK_DURATION)
+        POSITIONS_RARM_DEG = [-0.6, 0, -100, 15.2, 9.4, 3.2]
+        self.set_joint_angles_deg(self._GR_RARM, POSITIONS_RARM_DEG, TASK_DURATION,
+                              wait=True)
+        rospy.loginfo(self._goal_larm.trajectory.points)
+
+    def set_joint_angles_rad(self, groupname, positions_radian, duration=7.0,
+                             wait=False):
+        '''
+        @type groupname: str
+        @param groupname: This should exist in self.groupnames.
+        @type positions_radian: [double]
+        @type duration: double
+        @type wait: bool
+        '''
+        if groupname == self._GR_TORSO:
+            action_client = self._aclient_torso
+            goal = self._goal_torso
+        elif groupname == self._GR_HEAD:
+            action_client = self._aclient_head
+            goal = self._goal_head
+        elif groupname == self._GR_LARM:
+            action_client = self._aclient_larm
+            goal = self._goal_larm
+        elif groupname == self._GR_RARM:
+            action_client = self._aclient_rarm
+            goal = self._goal_rarm
+        else:
+            #TODO: Throw exception; a valid group name isn't passed.
+            pass
+
+        try:
+            pt = JointTrajectoryPoint()
+            pt.positions = positions_radian
+            pt.time_from_start = rospy.Duration(duration)
+            goal.trajectory.points = [pt]
+            goal.trajectory.header.stamp = \
+                             rospy.Time.now() + rospy.Duration(duration)
+
+            action_client.send_goal(goal)
+            if wait:
+                rospy.loginfo('wait_for_result for the joint group {} = {}'.format(
+                                   groupname, action_client.wait_for_result()))
+        except rospy.ROSInterruptException as e:
+            rospy.loginfo(e.str())
+
+    def set_joint_angles_deg(self, groupname, positions_deg, duration=7.0,
+                             wait=False):
+        '''
+        @type groupname: str
+        @param groupname: This should exist in self.groupnames.
+        @type positions_deg: [int]
+        @type duration: double
+        @type wait: bool
+        '''
+        self.set_joint_angles_rad(groupname, self._to_rad_list(positions_deg),
+                                  duration, wait)
+
+    def _to_rad_list(self, list_degree):
+        '''
+        @TODO Needs to be replaced by something more common, or at least moved
+              somewhere more common.
+
+        @type list_degree: [int]
+        @param list_degree: A list length of the number of joints.
+        '''
+        list_rad = []
+        for deg in list_degree:
+            rad = math.radians(deg)
+            list_rad.append(rad)
+            rospy.logdebug('Position deg={} rad={}'.format(deg, rad))
+        return list_rad

--- a/hironx_ros_bridge/src/hironx_ros_bridge/testutil/abst_acceptancetest.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/testutil/abst_acceptancetest.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2014, TORK (Tokyo Opensource Robotics Kyokai Association)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of TORK. nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import abc
+
+
+class AbstAcceptanceTest():
+
+    _MSG_ERR_NOTIMPLEMENTED = 'The method is not implemented in the derived class'
+
+    GRNAME_LEFT_ARM = 'larm'
+    GRNAME_RIGHT_ARM = 'rarm'
+    GRNAME_TORSO = 'torso'
+    GRNAME_HEAD = 'head'
+
+    def __init__(self, robot_client, default_task_duration=7.0):
+        '''
+        @type robot_client: hironx_ros_bridge.ros_client.ROS_Client or
+                            hrpsys.hrpsys_config.HrpsysConfigurator
+        '''
+        self._robotclient = robot_client
+        self._default_task_duration = default_task_duration
+
+    @abc.abstractmethod
+    def go_initpos(self, default_task_duration=7.0):
+        raise NotImplementedError(self._MSG_ERR_NOTIMPLEMENTED)
+
+    @abc.abstractmethod
+    def set_joint_angles(self, joint_group, joint_angles,
+                  msg_tasktitle=None, task_duration=7.0, do_wait=True):
+        '''
+        Move by passing joint angles of an arm.
+
+        @type joint_group: str
+        @type joint_angles: [double]
+        @type msg_tasktitle: str
+        @type task_duration: double
+        '''
+        raise NotImplementedError(self._MSG_ERR_NOTIMPLEMENTED)
+
+    @abc.abstractmethod
+    def set_pose(self, joint_group, pose, rpy, msg_tasktitle=None,
+                 task_duration=7.0, do_wait=True, ref_frame_name=None):
+        raise NotImplementedError(self._MSG_ERR_NOTIMPLEMENTED)
+
+    @abc.abstractmethod
+    def set_pose_relative(
+                        self, joint_group, dx=0, dy=0, dz=0, dr=0, dp=0, dw=0,
+                        msg_tasktitle=None, task_duration=7.0, do_wait=True):
+        '''        '''
+        raise NotImplementedError(self._MSG_ERR_NOTIMPLEMENTED)

--- a/hironx_ros_bridge/src/hironx_ros_bridge/testutil/acceptancetest_ros.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/testutil/acceptancetest_ros.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2014, TORK (Tokyo Opensource Robotics Kyokai Association)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of TORK. nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import rospy
+
+from hironx_ros_bridge.testutil.abst_acceptancetest import AbstAcceptanceTest
+
+
+class AcceptanceTestROS(AbstAcceptanceTest):
+
+    def __init__(self, robot_client):
+        '''
+        @type robot_client: hironx_ros_bridge.ros_client.ROS_Client
+        '''
+        self._robotclient = robot_client
+        self._robotclient.init_action_clients()
+
+    def go_initpos(self, default_task_duration=7.0):
+        self._robotclient.go_init(default_task_duration)
+
+    def set_joint_angles(self, joint_group, joint_angles, msg_tasktitle=None,
+                         task_duration=7.0, do_wait=True):
+        '''
+        @see: AbstAcceptanceTest.move_armbyarm_impl
+        '''
+        rospy.loginfo("'''{}'''".format(msg_tasktitle))
+        self._robotclient.set_joint_angles_deg(
+                         joint_group, joint_angles, task_duration, do_wait)
+
+    def set_pose_relative(
+                        self, joint_group, dx=0, dy=0, dz=0, dr=0, dp=0, dw=0,
+                        msg_tasktitle=None, task_duration=7.0, do_wait=True):
+        rospy.loginfo('*** Task4 begins; move arm w/small increments ***')
+        rospy.logwarn('*** Task4 is not yet implemented with ROS. Need to' +
+                      ' figure out how. ***')
+        pass

--- a/hironx_ros_bridge/src/hironx_ros_bridge/testutil/acceptancetest_ros.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/testutil/acceptancetest_ros.py
@@ -58,10 +58,12 @@ class AcceptanceTestROS(AbstAcceptanceTest):
         self._robotclient.set_joint_angles_deg(
                          joint_group, joint_angles, task_duration, do_wait)
 
+    def set_pose(self, joint_group, pose, rpy, msg_tasktitle=None,
+                 task_duration=7.0, do_wait=True, ref_frame_name=None):
+        rospy.logerr('AcceptanceTestROS) set_pose is not implemented yet.')
+
     def set_pose_relative(
                         self, joint_group, dx=0, dy=0, dz=0, dr=0, dp=0, dw=0,
                         msg_tasktitle=None, task_duration=7.0, do_wait=True):
-        rospy.loginfo('*** Task4 begins; move arm w/small increments ***')
-        rospy.logwarn('*** Task4 is not yet implemented with ROS. Need to' +
-                      ' figure out how. ***')
+        rospy.logerr('AcceptanceTestROS; set_pose_relative is not implemented yet')
         pass

--- a/hironx_ros_bridge/src/hironx_ros_bridge/testutil/acceptancetest_rtm.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/testutil/acceptancetest_rtm.py
@@ -1,0 +1,216 @@
+# -*- coding: utf-8 -*-
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2014, TORK (Tokyo Opensource Robotics Kyokai Association)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of TORK. nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import time
+
+from hironx_ros_bridge.testutil.abst_acceptancetest import AbstAcceptanceTest
+
+
+class AcceptanceTestRTM(AbstAcceptanceTest):
+
+    def __init__(self, robot_client):
+        '''
+        @type robot_client: hironx_ros_bridge.hironx_client.HIRONX
+        '''
+        self._robotclient = robot_client
+
+    def go_initpos(self):
+        self._robotclient.goInitial()
+
+    def set_joint_angles(self, joint_group, joint_angles, msg_tasktitle=None,
+                         task_duration=7.0, do_wait=True):
+        '''
+        @see: AbstAcceptanceTest.set_joint_angles
+        '''
+        print("== RTM; {} ==".format(msg_tasktitle))
+        self._robotclient.setJointAnglesOfGroup(
+                         joint_group, joint_angles, task_duration, do_wait)
+
+    def set_pose(self, joint_group, pose, rpy, msg_tasktitle,
+                      task_duration=7.0, do_wait=True, ref_frame_name=None):
+
+        print("== RTM; {} ==".format(msg_tasktitle))
+        self._robotclient.setTargetPose(joint_group, pose, rpy, task_duration,
+                                        ref_frame_name)
+        if do_wait:
+            self._robotclient.waitInterpolationOfGroup(joint_group)
+
+    def set_pose_relative(
+                        self, joint_group, dx=0, dy=0, dz=0, dr=0, dp=0, dw=0,
+                        msg_tasktitle=None, task_duration=7.0, do_wait=True):
+        if joint_group == self.GRNAME_LEFT_ARM:
+            eef = 'LARM_JOINT5'
+        elif joint_group == self.GRNAME_RIGHT_ARM:
+            eef = 'RARM_JOINT5'
+
+        print("== RTM; {} ==".format(msg_tasktitle))
+        self._robotclient.setTargetPoseRelative(
+                                    joint_group, eef, dx, dy, dz, dr, dp, dw,
+                                    task_duration, do_wait)
+
+    def _run_tests_hrpsys(self):
+        '''
+        @deprecated: This method remains as a reference. This used to function
+                     when being called directly from ipython commandline and
+                     now replaced by optimized codes.
+        '''
+        _TIME_SETTARGETP_L = 3
+        _TIME_SETTARGETP_R = 2
+        _TIME_BW_TESTS = 5
+
+        self.robot.goInitial()
+
+        # === TASK-1 ===
+        # L arm setTargetPose
+        _POS_L_INIT = self.robot.getCurrentPosition('LARM_JOINT5')
+        _POS_L_INIT[2] += 0.8
+        _RPY_L_INIT = self.robot.getCurrentRPY('LARM_JOINT5')
+        self.robot.setTargetPose('larm', _POS_L_INIT, _RPY_L_INIT, _TIME_SETTARGETP_L)
+        self.robot.waitInterpolationOfGroup('larm')
+
+        # R arm setTargetPose
+        _POS_R_INIT = self.robot.getCurrentPosition('RARM_JOINT5')
+        _POS_R_INIT[2] -= 0.07
+        _RPY_R_INIT = self.robot.getCurrentRPY('RARM_JOINT5')
+        self.robot.setTargetPose('rarm', _POS_R_INIT, _RPY_R_INIT, _TIME_SETTARGETP_R)
+        self.robot.waitInterpolationOfGroup('rarm')
+        time.sleep(_TIME_BW_TESTS)
+
+        # === TASK-2 === 
+        self.robot.goInitial()
+        # Both arm setTargetPose
+        _Z_SETTARGETP_L = 0.08
+        _Z_SETTARGETP_R = 0.08
+        self.robot.setTargetPoseRelative('larm', 'LARM_JOINT5',
+                                         dz=_Z_SETTARGETP_L,
+                                         tm=_TIME_SETTARGETP_L, wait=False)
+        self.robot.setTargetPoseRelative('rarm', 'RARM_JOINT5',
+                                         dz=_Z_SETTARGETP_R,
+                                         tm=_TIME_SETTARGETP_R, wait=False)
+
+        # === TASK-3 ===
+        # Head toward down
+        _TIME_HEAD = 5
+        self.robot.setTargetPoseRelative('head', 'HEAD_JOINT0', dp=0.1, tm=_TIME_HEAD)
+        self.robot.waitInterpolationOfGroup('head')
+        # Head toward up
+        self.robot.setTargetPoseRelative('head', 'HEAD_JOINT0', dp=-0.2, tm=_TIME_HEAD)
+        self.robot.waitInterpolationOfGroup('head')
+        # See left by position
+        self.robot.setJointAnglesOfGroup('head', [50, 10], 2, wait=True)
+        # See right by position
+        self.robot.setJointAnglesOfGroup('head', [-50, -10], 2, wait=True)
+        # Set back face to the starting pose w/o wait. 
+        self.robot.setJointAnglesOfGroup( 'head', [0, 0], 2, wait=False)
+
+        # === TASK-4 ===
+        # 0.1mm increment is not working for some reason.
+        self.robot.goInitial()
+        # Move by iterating 0.1mm at cartesian space
+        _TIME_CARTESIAN = 0.1
+        _INCREMENT_MIN = 0.0001
+        for i in range(300):
+            self.robot.setTargetPoseRelative('larm', 'LARM_JOINT5',
+                                             dy=_INCREMENT_MIN,
+                                             tm=_TIME_CARTESIAN)
+            self.robot.setTargetPoseRelative('rarm', 'RARM_JOINT5',
+                                             dy=_INCREMENT_MIN,
+                                             tm=_TIME_CARTESIAN)
+            print('{}th move'.format(i))
+
+        self.robot.goInitial()
+        # === TASK-5 ===
+        # Turn torso
+        _TORSO_ANGLE = 120
+        _TIME_TORSO_R = 7
+        self.robot.setJointAnglesOfGroup('torso', [_TORSO_ANGLE], _TIME_TORSO_R, wait=True)
+        self.robot.waitInterpolationOfGroup('torso')
+        self.robot.setJointAnglesOfGroup('torso', [-_TORSO_ANGLE], 10, wait=True)
+ 
+        self.robot.goInitial()
+
+        # === TASK-6.1 ===
+        # Overwrite previous command, for torso using setJointAnglesOfGroup
+        self.robot.setJointAnglesOfGroup('torso', [_TORSO_ANGLE], _TIME_TORSO_R,
+                                         wait=False)
+        time.sleep(1)
+        self.robot.setJointAnglesOfGroup('torso', [-_TORSO_ANGLE], 10, wait=True)
+
+        self.robot.goInitial(5)
+
+        # === TASK-6.2 ===
+        # Overwrite previous command, for arms using setTargetPose
+        _X_EEF_OVERWRITE = 0.05
+        _Z_EEF_OVERWRITE = 0.1
+        _TIME_EEF_OVERWRITE = 7
+        _POS_L_INIT[0] += _X_EEF_OVERWRITE
+        _POS_L_INIT[2] += _Z_EEF_OVERWRITE
+        self.robot.setTargetPose('larm', _POS_L_INIT, _RPY_L_INIT, _TIME_EEF_OVERWRITE)
+        self.robot.waitInterpolationOfGroup('larm')
+        # Trying to raise rarm to the same level of larm.
+        _POS_R_INIT[0] += _X_EEF_OVERWRITE
+        _POS_R_INIT[2] += _Z_EEF_OVERWRITE
+        self.robot.setTargetPose('rarm', _POS_R_INIT, _RPY_R_INIT, _TIME_EEF_OVERWRITE)
+        self.robot.waitInterpolationOfGroup('rarm')
+        time.sleep(3)
+        # Stop rarm
+        self.robot.clearOfGroup('rarm')  # Movement should stop here.
+
+        # === TASK-7.1 ===
+        # Cover wide workspace.
+        _TIME_COVER_WORKSPACE = 3
+        # Close to the max width the robot can spread arms with the hand kept
+        # at table level.
+        _POS_L_X_NEAR_Y_FAR = [0.32552812002303166, 0.47428609880442024, 1.0376656470275407]
+        _RPY_L_X_NEAR_Y_FAR = (-3.07491977663752, -1.5690249316560323, 3.074732073335767)
+        _POS_R_X_NEAR_Y_FAR = [0.32556456455769633, -0.47239119592815987, 1.0476131608682244]
+        _RPY_R_X_NEAR_Y_FAR = (3.072515432213872, -1.5690200270375372, -3.072326882451363)
+
+        # Close to the farthest distance the robot can reach, with the hand kept
+        # at table level.
+        _POS_L_X_FAR_Y_FAR = [0.47548142379781055, 0.17430276793604782, 1.0376878025614884]
+        _RPY_L_X_FAR_Y_FAR = (-3.075954857224205, -1.5690261926181046, 3.0757659493049574)
+        _POS_R_X_FAR_Y_FAR = [0.4755337947019357, -0.17242322190721648, 1.0476395479774052]
+        _RPY_R_X_FAR_Y_FAR = (3.0715850722714944, -1.5690204449882248, -3.071395243174742)
+        self.robot.setTargetPose('larm', _POS_L_X_NEAR_Y_FAR, _RPY_L_X_NEAR_Y_FAR, _TIME_COVER_WORKSPACE)
+        self.robot.setTargetPose('rarm', _POS_R_X_NEAR_Y_FAR, _RPY_R_X_NEAR_Y_FAR, _TIME_COVER_WORKSPACE)
+        self.robot.waitInterpolationOfGroup('larm')
+        self.robot.waitInterpolationOfGroup('rarm')
+        time.sleep(3)
+        self.robot.setTargetPose('larm', _POS_L_X_FAR_Y_FAR, _RPY_L_X_FAR_Y_FAR, _TIME_COVER_WORKSPACE)
+        self.robot.setTargetPose('rarm', _POS_R_X_FAR_Y_FAR, _RPY_R_X_FAR_Y_FAR, _TIME_COVER_WORKSPACE)
+        self.robot.waitInterpolationOfGroup('larm')
+        self.robot.waitInterpolationOfGroup('rarm')
+
+        self.robot.goInitial()

--- a/hironx_ros_bridge/test/acceptancetest_hironx.py
+++ b/hironx_ros_bridge/test/acceptancetest_hironx.py
@@ -34,101 +34,11 @@
 
 import time
 
-import rospy
-
 from hironx_ros_bridge.hironx_client import HIRONX
-
-
-class AcTestRos():
-    _TIME_DURATION_DEFAULT = 5.0
-    _POSITIONS_LARM_DEG_UP = [-4.697, -2.012, -117.108, -17.180, 29.146, -3.739]
-    _POSITIONS_LARM_DEG_DOWN = [6.196, -5.311, -73.086, -15.287, -12.906, -2.957]
-    _POSITIONS_RARM_DEG_DOWN = [-4.949, -3.372, -80.050, 15.067, -7.734, 3.086]
-    _POSITIONS_LARM_DEG_UP_SYNC = [-4.695, -2.009, -117.103, -17.178, 29.138, -3.738]
-    _POSITIONS_RARM_DEG_SYNC = [4.695, -2.009, -117.103, 17.178, 29.138, 3.738]
-
-    def __init__(self, robot_client):
-        self._robotclient = robot_client
-
-    def _ros_task1_move_armbyarm(self):
-        rospy.loginfo('*** task1 begins ***')
-        self._robotclient.ros.go_init()
-        TASK_DURATION = self._TIME_DURATION_DEFAULT
-        self._robotclient.ros.set_joint_angles_deg(
-                      'larm', self._POSITIONS_LARM_DEG_UP, TASK_DURATION, True)
-        self._robotclient.ros.set_joint_angles_deg(
-                    'rarm', self._POSITIONS_RARM_DEG_DOWN, TASK_DURATION, True)
-        time.sleep(2.0)
-
-    def _ros_task2_movearms_together(self):
-        rospy.loginfo('*** task2 begins ***')
-        self._robotclient.ros.go_init()
-        TASK_DURATION = self._TIME_DURATION_DEFAULT
-        self._robotclient.ros.set_joint_angles_deg(
-                 'larm', self._POSITIONS_LARM_DEG_UP_SYNC, TASK_DURATION, True)
-        self._robotclient.ros.set_joint_angles_deg(
-                 'rarm', self._POSITIONS_RARM_DEG_SYNC, TASK_DURATION)
-        time.sleep(2.0)
-
-    def _ros_task3_move_head(self):
-        rospy.loginfo('*** task3 begins; See up and down. ***')
-        self._robotclient.ros.go_init()
-        TASK_DURATION = self._TIME_DURATION_DEFAULT
-        rotations = [[0.1, 0.0], [50.0, 10.0]]
-        for rotation in rotations:
-            self._robotclient.ros.set_joint_angles_deg('head', rotation,
-                                                       TASK_DURATION, True)
-
-        rospy.loginfo('*** task3; Rotating. ***')
-        TASK_DURATION_ROT = 4
-        ROTATION_POSITIONS = [[50, 10], [-50, -10], [0, 0]]
-        for positions in ROTATION_POSITIONS:
-            self._robotclient.ros.set_joint_angles_deg('head', positions,
-                                                   TASK_DURATION_ROT, True)
-            self._robotclient.ros.set_joint_angles_deg('head', positions,
-                                                   TASK_DURATION_ROT, True)
-
-    def _ros_task4_cartesian_smallinc(self):
-        rospy.loginfo('*** Task4 begins; move arm w/small increments ***')
-        self._robotclient.ros.go_init()
-        rospy.loginfo('*** Task4 is not yet implemented with ROS. Need to' +
-                      ' figure out how. ***')
-
-    def _ros_task5_torso(self):
-        rospy.loginfo('*** Task5 begins. Turn torso ***')
-        self._robotclient.ros.go_init()
-        TASK_DURATION = self._TIME_DURATION_DEFAULT
-        POSITIONS_TORSO_DEG = [[130.0], [-130.0]]
-        for positions in POSITIONS_TORSO_DEG:
-            self._robotclient.ros.set_joint_angles_deg('torso', positions,
-                                                       TASK_DURATION, True)
-
-    def _ros_task6_overwrite_torso(self):
-        rospy.loginfo('*** Task6-1 begins. Overwrite previous command. ***')
-        self._robotclient.ros.go_init()
-        TASK_DURATION = 7
-        ROTATION_TORSO_DEGS = [[130.0], [-130.0]]
-        self._robotclient.ros.set_joint_angles_deg(
-                      'torso', ROTATION_TORSO_DEGS[0], TASK_DURATION, False)
-        time.sleep(2.0)
-        self._robotclient.ros.set_joint_angles_deg(
-                      'torso', ROTATION_TORSO_DEGS[1], TASK_DURATION, True)
-        time.sleep(2.0)
-
-    def _ros_task6_overwrite_arm(self):
-        rospy.loginfo('*** Task6-2 begins. Overwrite previous arm command.' +
-                      '\n\tIn the beginning both arm starts to move to the' +
-                      '\n\tsame height, but to the left arm interrupting' +
-                      '\ncommand is sent and it goes downward. ***')
-        self._robotclient.ros.go_init()
-        TASK_DURATION = 5
-        self._robotclient.ros.set_joint_angles_deg(
-                'larm', self._POSITIONS_LARM_DEG_UP_SYNC, TASK_DURATION, False)
-        self._robotclient.ros.set_joint_angles_deg(
-                'rarm', self._POSITIONS_RARM_DEG_SYNC, TASK_DURATION)
-        time.sleep(2.0)
-        self._robotclient.ros.set_joint_angles_deg(
-                'larm', self._POSITIONS_LARM_DEG_DOWN, TASK_DURATION, False)
+from hironx_ros_bridge.ros_client import ROS_Client
+from hironx_ros_bridge.testutil.abst_acceptancetest import AbstAcceptanceTest
+from hironx_ros_bridge.testutil.acceptancetest_ros import AcceptanceTestROS
+from hironx_ros_bridge.testutil.acceptancetest_rtm import AcceptanceTestRTM
 
 
 class AcceptanceTest_Hiro():
@@ -150,154 +60,222 @@ class AcceptanceTest_Hiro():
     All time arguments are second.
     '''
 
-    def init(self, robotname='HiroNX(Robot)0', url=''):
-        self.robot = hiro = HIRONX()
-        self.robot.init(robotname=args.robot, url=args.modelfile)
+    _POSITIONS_LARM_DEG_UP = [-4.697, -2.012, -117.108, -17.180, 29.146, -3.739]
+    _POSITIONS_LARM_DEG_DOWN = [6.196, -5.311, -73.086, -15.287, -12.906, -2.957]
+    _POSITIONS_RARM_DEG_DOWN = [-4.949, -3.372, -80.050, 15.067, -7.734, 3.086]
+    _POSITIONS_LARM_DEG_UP_SYNC = [-4.695, -2.009, -117.103, -17.178, 29.138, -3.738]
+    _POSITIONS_RARM_DEG_UP_SYNC = [4.695, -2.009, -117.103, 17.178, 29.138, 3.738]
+    _ROTATION_ANGLES_HEAD_1 = [[0.1, 0.0], [50.0, 10.0]]
+    _ROTATION_ANGLES_HEAD_2 = [[50, 10], [-50, -10], [0, 0]]
+    _POSITIONS_TORSO_DEG = [[130.0], [-130.0]]
+    _R_Z_SMALLINCREMENT = 0.0001
+    # Workspace; X near, Y far
+    _POS_L_X_NEAR_Y_FAR = [0.326, 0.474, 1.038]
+    _RPY_L_X_NEAR_Y_FAR = (-3.075, -1.569, 3.074)
+    _POS_R_X_NEAR_Y_FAR = [0.326, -0.472, 1.048]
+    _RPY_R_X_NEAR_Y_FAR = (3.073, -1.569, -3.072)
+    # Workspace; X far, Y far
+    _POS_L_X_FAR_Y_FAR = [0.47548142379781055, 0.17430276793604782, 1.0376878025614884]
+    _RPY_L_X_FAR_Y_FAR = (-3.075954857224205, -1.5690261926181046, 3.0757659493049574)
+    _POS_R_X_FAR_Y_FAR = [0.4755337947019357, -0.17242322190721648, 1.0476395479774052]
+    _RPY_R_X_FAR_Y_FAR = (3.0715850722714944, -1.5690204449882248, -3.071395243174742)
 
-    def run_tests_ros(self):
+    _TASK_DURATION_DEFAULT = 5.0
+    _DURATION_EACH_SMALLINCREMENT = 0.1
+    _TASK_DURATION_TORSO = 4.0
+    _TASK_DURATION_HEAD = 2.5
+
+    _DURATON_TOTAL_SMALLINCREMENT = 30  # Second.
+
+    def __init__(self, rtm_robotname='HiroNX(Robot)0', url=''):
+        self._rtm_robotname = rtm_robotname
+        self._rtm_url = url
+
+        self._acceptance_ros_client = None
+        self._acceptance_rtm_client = None
+
+    def _wait_input(self, do_wait_input=False):
         '''
-        Run by ROS exactly the same actions that run_tests_hrpsys performs. 
+        @param do_wait_input: If True python commandline waits for any input
+                              to proceed.
         '''
-        test_ros = AcTestRos(self.robot)
-        test_ros._robotclient.ros.go_init()
-        test_ros._ros_task1_move_armbyarm()
-        test_ros._ros_task2_movearms_together()
-        test_ros._ros_task3_move_head()
-        test_ros._ros_task4_cartesian_smallinc()
-        test_ros._ros_task5_torso()
-        test_ros._ros_task6_overwrite_torso()
-        test_ros._ros_task6_overwrite_arm()
+        if do_wait_input:
+            input('Waiting for any key pressed.')
 
-    def run_tests_hrpsys(self):
-        _TIME_SETTARGETP_L = 3
-        _TIME_SETTARGETP_R = 2
-        _TIME_BW_TESTS = 5
+    def run_tests_rtm(self, do_wait_input=False):
+        '''
+        @param do_wait_input: If True, the user will be asked to hit any key
+                              before each task to proceed.
+        '''
+        if not self._acceptance_rtm_client:
+            _rtm_client = HIRONX()
+            _rtm_client.init(robotname=self._rtm_robotname, url=self._rtm_url)
+            self._acceptance_rtm_client = AcceptanceTestRTM(_rtm_client)
+        self._run_tests(self._acceptance_rtm_client, do_wait_input)
 
-        self.robot.goInitial()
+    def run_tests_ros(self, do_wait_input=False):
+        '''
+        Run by ROS exactly the same actions that run_tests_rtm performs.
 
-        # === TASK-1 ===
-        # L arm setTargetPose
-        _POS_L_INIT = self.robot.getCurrentPosition('LARM_JOINT5')
-        _POS_L_INIT[2] += 0.8
-        _RPY_L_INIT = self.robot.getCurrentRPY('LARM_JOINT5')
-        self.robot.setTargetPose('larm', _POS_L_INIT, _RPY_L_INIT, _TIME_SETTARGETP_L)
-        self.robot.waitInterpolationOfGroup('larm')
+        @param do_wait_input: If True, the user will be asked to hit any key
+                              before each task to proceed.
+        '''
+        if not self._acceptance_ros_client:
+            self._acceptance_ros_client = AcceptanceTestROS(ROS_Client())
+        self._run_tests(self._acceptance_ros_client, do_wait_input)
 
-        # R arm setTargetPose
-        _POS_R_INIT = self.robot.getCurrentPosition('RARM_JOINT5')
-        _POS_R_INIT[2] -= 0.07
-        _RPY_R_INIT = self.robot.getCurrentRPY('RARM_JOINT5')
-        self.robot.setTargetPose('rarm', _POS_R_INIT, _RPY_R_INIT, _TIME_SETTARGETP_R)
-        self.robot.waitInterpolationOfGroup('rarm')
-        time.sleep(_TIME_BW_TESTS)
+    def _run_tests(self, test_client, do_wait_input=False):
+        '''
+        @type test_client: hironx_ros_robotics.abst_acceptancetest.AbstAcceptanceTest
+        '''
 
-        # === TASK-2 === 
-        self.robot.goInitial()
-        # Both arm setTargetPose
-        _Z_SETTARGETP_L = 0.08
-        _Z_SETTARGETP_R = 0.08
-        self.robot.setTargetPoseRelative('larm', 'LARM_JOINT5',
-                                         dz=_Z_SETTARGETP_L,
-                                         tm=_TIME_SETTARGETP_L, wait=False)
-        self.robot.setTargetPoseRelative('rarm', 'RARM_JOINT5',
-                                         dz=_Z_SETTARGETP_R,
-                                         tm=_TIME_SETTARGETP_R, wait=False)
+        test_client.go_initpos()
+        self._wait_input(do_wait_input)
+        # Procedure in the methods in test_client with the same name are run
+        # between pre and post processes defined in in AbstAcceptanceTest.
 
-        # === TASK-3 ===
-        # Head toward down
-        _TIME_HEAD = 5
-        self.robot.setTargetPoseRelative('head', 'HEAD_JOINT0', dp=0.1, tm=_TIME_HEAD)
-        self.robot.waitInterpolationOfGroup('head')
-        # Head toward up
-        self.robot.setTargetPoseRelative('head', 'HEAD_JOINT0', dp=-0.2, tm=_TIME_HEAD)
-        self.robot.waitInterpolationOfGroup('head')
-        # See left by position
-        self.robot.setJointAnglesOfGroup('head', [50, 10], 2, wait=True)
-        # See right by position
-        self.robot.setJointAnglesOfGroup('head', [-50, -10], 2, wait=True)
-        # Set back face to the starting pose w/o wait. 
-        self.robot.setJointAnglesOfGroup( 'head', [0, 0], 2, wait=False)
+        #Task1
+        self._move_armbyarm(test_client)
 
-        # === TASK-4 ===
-        # 0.1mm increment is not working for some reason.
-        self.robot.goInitial()
-        # Move by iterating 0.1mm at cartesian space
-        _TIME_CARTESIAN = 0.1
-        _INCREMENT_MIN = 0.0001
-        for i in range(300):
-            self.robot.setTargetPoseRelative('larm', 'LARM_JOINT5',
-                                             dy=_INCREMENT_MIN,
-                                             tm=_TIME_CARTESIAN)
-            self.robot.setTargetPoseRelative('rarm', 'RARM_JOINT5',
-                                             dy=_INCREMENT_MIN,
-                                             tm=_TIME_CARTESIAN)
-            print('{}th move'.format(i))
+        #task2
+        self._wait_input(do_wait_input)
+        self._movearms_together(test_client)
 
-        self.robot.goInitial()
-        # === TASK-5 ===
-        # Turn torso
-        _TORSO_ANGLE = 120
-        _TIME_TORSO_R = 7
-        self.robot.setJointAnglesOfGroup('torso', [_TORSO_ANGLE], _TIME_TORSO_R, wait=True)
-        self.robot.waitInterpolationOfGroup('torso')
-        self.robot.setJointAnglesOfGroup('torso', [-_TORSO_ANGLE], 10, wait=True)
- 
-        self.robot.goInitial()
+        #task3
+        self._set_pose_relative(test_client)
+        self._wait_input(do_wait_input)
 
-        # === TASK-6.1 ===
-        # Overwrite previous command, for torso using setJointAnglesOfGroup
-        self.robot.setJointAnglesOfGroup('torso', [_TORSO_ANGLE], _TIME_TORSO_R,
-                                         wait=False)
-        time.sleep(1)
-        self.robot.setJointAnglesOfGroup('torso', [-_TORSO_ANGLE], 10, wait=True)
+        #task4
+        self._move_head(test_client)
+        self._wait_input(do_wait_input)
 
-        self.robot.goInitial(5)
+        #task5
+        self._move_torso(test_client)
+        self._wait_input(do_wait_input)
 
-        # === TASK-6.2 ===
-        # Overwrite previous command, for arms using setTargetPose
-        _X_EEF_OVERWRITE = 0.05
-        _Z_EEF_OVERWRITE = 0.1
-        _TIME_EEF_OVERWRITE = 7
-        _POS_L_INIT[0] += _X_EEF_OVERWRITE
-        _POS_L_INIT[2] += _Z_EEF_OVERWRITE
-        self.robot.setTargetPose('larm', _POS_L_INIT, _RPY_L_INIT, _TIME_EEF_OVERWRITE)
-        self.robot.waitInterpolationOfGroup('larm')
-        # Trying to raise rarm to the same level of larm.
-        _POS_R_INIT[0] += _X_EEF_OVERWRITE
-        _POS_R_INIT[2] += _Z_EEF_OVERWRITE
-        self.robot.setTargetPose('rarm', _POS_R_INIT, _RPY_R_INIT, _TIME_EEF_OVERWRITE)
-        self.robot.waitInterpolationOfGroup('rarm')
-        time.sleep(3)
-        # Stop rarm
-        self.robot.clearOfGroup('rarm')  # Movement should stop here.
+        #task6-1
+        self._overwrite_torso(test_client)
+        #task6-2
+        self._overwrite_arm(test_client)
+        self._wait_input(do_wait_input)
 
-        # === TASK-7.1 ===
-        # Cover wide workspace.
-        _TIME_COVER_WORKSPACE = 3
-        # Close to the max width the robot can spread arms with the hand kept
-        # at table level.
-        _POS_L_X_NEAR_Y_FAR = [0.32552812002303166, 0.47428609880442024, 1.0376656470275407]
-        _RPY_L_X_NEAR_Y_FAR = (-3.07491977663752, -1.5690249316560323, 3.074732073335767)
-        _POS_R_X_NEAR_Y_FAR = [0.32556456455769633, -0.47239119592815987, 1.0476131608682244]
-        _RPY_R_X_NEAR_Y_FAR = (3.072515432213872, -1.5690200270375372, -3.072326882451363)
+        #task7
+        self._show_workspace(test_client)
 
-        # Close to the farthest distance the robot can reach, with the hand kept
-        # at table level.
-        _POS_L_X_FAR_Y_FAR = [0.47548142379781055, 0.17430276793604782, 1.0376878025614884]
-        _RPY_L_X_FAR_Y_FAR = (-3.075954857224205, -1.5690261926181046, 3.0757659493049574)
-        _POS_R_X_FAR_Y_FAR = [0.4755337947019357, -0.17242322190721648, 1.0476395479774052]
-        _RPY_R_X_FAR_Y_FAR = (3.0715850722714944, -1.5690204449882248, -3.071395243174742)
-        self.robot.setTargetPose('larm', _POS_L_X_NEAR_Y_FAR, _RPY_L_X_NEAR_Y_FAR, _TIME_COVER_WORKSPACE)
-        self.robot.setTargetPose('rarm', _POS_R_X_NEAR_Y_FAR, _RPY_R_X_NEAR_Y_FAR, _TIME_COVER_WORKSPACE)
-        self.robot.waitInterpolationOfGroup('larm')
-        self.robot.waitInterpolationOfGroup('rarm')
-        time.sleep(3)
-        self.robot.setTargetPose('larm', _POS_L_X_FAR_Y_FAR, _RPY_L_X_FAR_Y_FAR, _TIME_COVER_WORKSPACE)
-        self.robot.setTargetPose('rarm', _POS_R_X_FAR_Y_FAR, _RPY_R_X_FAR_Y_FAR, _TIME_COVER_WORKSPACE)
-        self.robot.waitInterpolationOfGroup('larm')
-        self.robot.waitInterpolationOfGroup('rarm')
+    def _move_armbyarm(self, test_client):
+        '''
+        @type test_client: hironx_ros_robotics.abst_acceptancetest.AbstAcceptanceTest  
+        '''
+        test_client.go_initpos()
+        arm = AbstAcceptanceTest.GRNAME_LEFT_ARM
+        test_client.set_joint_angles(arm, self._POSITIONS_LARM_DEG_UP,
+                                     'Task1 {}'.format(arm))
 
-        self.robot.goInitial()
+        arm = AbstAcceptanceTest.GRNAME_RIGHT_ARM
+        test_client.set_joint_angles(arm, self._POSITIONS_RARM_DEG_DOWN,
+                                     'Task1 {}'.format(arm))
+        time.sleep(2.0)
+
+    def _movearms_together(self, test_client):
+        '''
+        @type test_client: hironx_ros_robotics.abst_acceptancetest.AbstAcceptanceTest  
+        '''
+        test_client.go_initpos()
+        arm = AbstAcceptanceTest.GRNAME_LEFT_ARM
+        test_client.set_joint_angles(
+                 arm, self._POSITIONS_LARM_DEG_UP_SYNC, 'Task2 {}'.format(arm),
+                 self._TASK_DURATION_DEFAULT, False)
+                #'task2; Under current implementation, left arm ' +
+                #'always moves first, followed immediately by right arm')
+        arm = AbstAcceptanceTest.GRNAME_RIGHT_ARM
+        test_client.set_joint_angles(
+                    arm, self._POSITIONS_RARM_DEG_DOWN, 'Task2 {}'.format(arm),
+                    self._TASK_DURATION_DEFAULT, False)
+        time.sleep(2.0)
+
+    def _set_pose_relative(self, test_client):
+        delta = self._R_Z_SMALLINCREMENT
+        t = self._DURATION_EACH_SMALLINCREMENT
+        t_total_sec = self._DURATON_TOTAL_SMALLINCREMENT
+        total_increment = int(t_total_sec / t)
+        msg_1 = 'Task3; right arm is moving upward with' + \
+              '{}mm increment per {}s'.format(delta, t)
+        msg_2 = ' (Total {}cm over {}s).'.format(delta * total_increment, t_total_sec)
+        print(msg_1 + msg_2)
+        for i in range(total_increment):
+            msg_eachloop = '{}th loop;'.format(i)
+            test_client.set_pose_relative(
+                     AbstAcceptanceTest.GRNAME_RIGHT_ARM, dz=delta,
+                     msg_tasktitle=msg_eachloop, task_duration=t, do_wait=True)
+
+    def _move_head(self, test_client):
+        test_client.go_initpos()
+
+        for positions in self._ROTATION_ANGLES_HEAD_1:
+            test_client.set_joint_angles(
+                               AbstAcceptanceTest.GRNAME_HEAD,
+                               positions, 'task4-1;', self._TASK_DURATION_HEAD)
+
+        for positions in self._ROTATION_ANGLES_HEAD_2:
+            test_client.set_joint_angles(
+                                     AbstAcceptanceTest.GRNAME_HEAD, positions,
+                                     'task4-2;', self._TASK_DURATION_HEAD)
+
+    def _move_torso(self, test_client):
+        test_client.go_initpos()
+        for positions in self._POSITIONS_TORSO_DEG:
+            test_client.set_joint_angles(AbstAcceptanceTest.GRNAME_TORSO,
+                                         positions, 'task5')
+
+    def _overwrite_torso(self, test_client):
+        test_client.go_initpos()
+        test_client.set_joint_angles(
+                        AbstAcceptanceTest.GRNAME_TORSO, self._POSITIONS_TORSO_DEG[0],
+                        'task5-1', self._TASK_DURATION_TORSO, False)
+        time.sleep(2.0)
+        test_client.set_joint_angles(
+                          AbstAcceptanceTest.GRNAME_TORSO, self._POSITIONS_TORSO_DEG[1],
+                          'task5-2', self._TASK_DURATION_TORSO, True)
+        time.sleep(2.0)
+
+    def _overwrite_arm(self, test_client):
+        test_client.go_initpos()
+        test_client.set_joint_angles(
+                    AbstAcceptanceTest.GRNAME_LEFT_ARM, self._POSITIONS_LARM_DEG_UP_SYNC,
+                    'task6-1', self._TASK_DURATION_DEFAULT, False)
+        test_client.set_joint_angles(
+                   AbstAcceptanceTest.GRNAME_RIGHT_ARM, self._POSITIONS_RARM_DEG_UP_SYNC,
+                   'Task6-2 begins. Overwrite previous arm command.' +
+                   '\n\tIn the beginning both arm starts to move to the' +
+                   '\n\tsame height, but to the left arm interrupting' +
+                   '\ncommand is sent and it goes downward.',
+                   self._TASK_DURATION_DEFAULT, False)
+        time.sleep(2.0)
+        test_client.set_joint_angles(
+                      AbstAcceptanceTest.GRNAME_LEFT_ARM, self._POSITIONS_LARM_DEG_DOWN,
+                      'task6-3', self._TASK_DURATION_DEFAULT, False)
+
+    def _show_workspace(self, test_client):
+        test_client.go_initpos()
+        msg = 'Task 7; '
+
+        larm = AbstAcceptanceTest.GRNAME_LEFT_ARM
+        rarm = AbstAcceptanceTest.GRNAME_RIGHT_ARM
+        # X near, Y far.
+        test_client.set_pose(
+                   larm, self._POS_L_X_NEAR_Y_FAR, self._RPY_L_X_NEAR_Y_FAR,
+                   msg + '{}'.format(larm), self._TASK_DURATION_DEFAULT, False)
+        test_client.set_pose(
+                   rarm, self._POS_R_X_NEAR_Y_FAR, self._RPY_R_X_NEAR_Y_FAR,
+                   msg + '{}'.format(rarm), self._TASK_DURATION_DEFAULT, True)
+
+        # X far, Y far.
+        test_client.set_pose(
+                   larm, self._POS_L_X_FAR_Y_FAR, self._RPY_L_X_FAR_Y_FAR,
+                   msg + '{}'.format(larm), self._TASK_DURATION_DEFAULT, False)
+        test_client.set_pose(
+                    rarm, self._POS_R_X_FAR_Y_FAR, self._RPY_R_X_FAR_Y_FAR,
+                    msg + '{}'.format(rarm), self._TASK_DURATION_DEFAULT, True)
 
 import argparse
 
@@ -325,4 +303,3 @@ if __name__ == '__main__':
         args.robot = unknown[0]
         args.modelfile = unknown[1]
     acceptance_test = AcceptanceTest_Hiro()
-    acceptance_test.init(robotname=args.robot, url=args.modelfile)


### PR DESCRIPTION
Some tasks that involve `Cartesian` and didn't look straightforward in ROS, are not implemented yet (task 4, 7). 

At this time `ROS_Client` class is added for the first time. This class provides simplified low-level ROS API (using `pr2_controllers_msgs.msg.JointTrajectoryAction`) for Hiro-NXO robot. Features available at this moment are still minimum, but as seen in task 6 in acceptance test py, interruption is achieved.

As mentioned above what's still missing is Cartesian control, which is possible with the same ROS interface, `JointTrajectoryAction`. [Explained in this tutorial](http://wiki.ros.org/pr2_controllers/Tutorials/Moving%20the%20arm%20through%20a%20Cartesian%20pose%20trajectory), though, it requires to create a `ROS Service` type, so `HrpsysConfigurator.setTargetRelative` seems simpler.

That said, I'm wondering whether (a) I should manage to implement task 4 and 7 in ROS or (b) leave Cartesian features to `hrpsys`. 

If we choose (b), a unified client class that provides all available features while encapsulating the detail of both hrpsys and ROS might be very useful for the users.
Also, creating a unified class doesn't mean users wouldn't be able to write directly in `hrpsys` nor `ROS`; API of those are still open to users.
