### PR TITLE
(hironx_ros_bridge launch files) Enable RobotHardwareServiceROSBridge for when working with real robot.

### DIFF
--- a/hironx_ros_bridge/launch/hironx_ros_bridge.launch
+++ b/hironx_ros_bridge/launch/hironx_ros_bridge.launch
@@ -11,6 +11,7 @@
   <arg name="corbaport" default="15005" />
   <arg name="CONF_FILE_COLLISIONDETECT" default="$(find hironx_ros_bridge)/conf/kawada-hironx.conf" /> <!-- Default is simulation -->
   <arg name="USE_COLLISIONCHECK" default="false" /> <!-- For running collsion detection inside the robot (QNX) -->
+  <arg name="USE_ROBOTHARDWARE" default="false" />
   <arg name="USE_SERVOCONTROLLER" default="false" />
 
   <include file="$(find hrpsys_ros_bridge)/launch/hrpsys_ros_bridge.launch">
@@ -23,6 +24,7 @@
     <!-- In hrpsys_ros_bridge.launch, Collision check might be turned on -->
     <arg name="USE_COLLISIONCHECK" value="$(arg USE_COLLISIONCHECK)" />
     <arg name="USE_IMPEDANCECONTROLLER" value="false" />
+    <arg name="USE_ROBOTHARDWARE" value="$(arg USE_ROBOTHARDWARE)" />
     <arg name="USE_SOFTERRORLIMIT" value="false" />
     <arg name="USE_SERVOCONTROLLER" value="$(arg USE_SERVOCONTROLLER)" />
 

--- a/hironx_ros_bridge/launch/hironx_ros_bridge_real.launch
+++ b/hironx_ros_bridge/launch/hironx_ros_bridge_real.launch
@@ -4,6 +4,7 @@
   <arg name="MODEL_FILE" default="/opt/jsk/etc/HIRONX/model/main.wrl" /> <!-- This shouldn't be changed unless you know what you're doing -->
   <arg name="nameserver" default="nx003" />
   <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
+  <arg name="USE_ROBOTHARDWARE" default="true" />
   <arg name="USE_SERVOCONTROLLER" default="true" />
 
   <include file="$(find hironx_ros_bridge)/launch/hironx_ros_bridge.launch" >
@@ -11,6 +12,7 @@
     <arg name="corbaport" default="$(arg corbaport)" />
     <arg name="MODEL_FILE" value="$(arg MODEL_FILE)" />
     <arg name="nameserver" value="$(arg nameserver)" />
+    <arg name="USE_ROBOTHARDWARE" value="$(arg USE_ROBOTHARDWARE)" />
     <arg name="USE_SERVOCONTROLLER" value="$(arg USE_SERVOCONTROLLER)" />
   </include>
 </launch>


### PR DESCRIPTION
Fixes servoOn/Off issue reported in https://github.com/start-jsk/rtmros_hironx/issues/138
