### PR TITLE
(robot install) Update the binary to Kawada's July 2014 qnx ssd spec. Move binary to the same folder with the trigger script.

### DIFF
--- a/hironx_ros_bridge/robot/check/md5sum_check.py
+++ b/hironx_ros_bridge/robot/check/md5sum_check.py
@@ -49,7 +49,7 @@ def md5sum_check_dir(dir_info, output_dir=''):
 
   filename = md5sum_check_filename(full_dir)
 
-  print "  Writingg results to ... ", os.path.join(output_dir, filename)
+  print "  Writing results to ... ", os.path.join(output_dir, filename)
   f = open(os.path.join(output_dir, filename), 'wb')
   print >> f, 'info=',
   pprint(info, f, width=240)

--- a/hironx_ros_bridge/robot/check/md5sum_opt_nextage_open.py
+++ b/hironx_ros_bridge/robot/check/md5sum_opt_nextage_open.py
@@ -1,4 +1,10 @@
-info={'/opt/nextage-open/lib/libNxOpenCore.so': '21a85801721eb5fcf86e0021e4e5264e',
+info={'/opt/nextage-open/bin/NxOpenCore': '2bd5dfca5f2d1a307d56b3a9a2b7dc7e',
+ '/opt/nextage-open/bin/diagnosisServer': 'e84eb328001a653e14c37e10b828419c',
+ '/opt/nextage-open/bin/startNextageOpen.sh': '604bd3d9bff4dd2257c0ff05e5157900',
+ '/opt/nextage-open/bin/unlock_iob': '3d985142d1ca6140016d78160384e48d',
+ '/opt/nextage-open/include/nextage-open.hpp': '8462aef0e622bad5e4fc55feb8667065',
+ '/opt/nextage-open/lib/libNxOpenCore.so': '21a85801721eb5fcf86e0021e4e5264e',
  '/opt/nextage-open/lib/libNxOpenCore.so.1': '21a85801721eb5fcf86e0021e4e5264e',
  '/opt/nextage-open/lib/libNxOpenCore.so.1.1.0': '21a85801721eb5fcf86e0021e4e5264e',
  '/opt/nextage-open/lib/libhrpIo.so': '3e4422baf1610048ea6b7e39e2fa53e4'}
+

--- a/hironx_ros_bridge/robot/check/qnx_cpu_check.py
+++ b/hironx_ros_bridge/robot/check/qnx_cpu_check.py
@@ -32,7 +32,7 @@ def qnx_cpu_check() :
     check_pinfo(info, 'CPU:\S+', "CPU:X86")
 
     print "  Check Memory Size .. ",
-    check_pinfo(info, 'FreeMem:\S+', "3318Mb")
+    check_pinfo(info, '(?<=Mb\/)\S+', "3318Mb")  # Positive-lookbehind assertion
 
     print "  Check OS Release .. ",
     check_pinfo(info, 'Release:\S+', "Release:6.5.0")

--- a/hironx_ros_bridge/robot/check/robot-system-check-base.py
+++ b/hironx_ros_bridge/robot/check/robot-system-check-base.py
@@ -71,7 +71,7 @@ try:
     ret = md5sum_check_dir(['/usr/pkg/share',  0x814de4e7c790d11dc4764139b5fb3625L], output_dir = tmp_dir) and ret
 
     print "* Check /opt/nextage-open directories"
-    ret = md5sum_check_dir(['/opt/nextage-open',    0x5644cb667d7241ebec88d79b610b4558L], output_dir = tmp_dir) and ret
+    ret = md5sum_check_dir(['/opt/nextage-open',    0x5c63a325454cc0dc9c1614c427705a0L], output_dir = tmp_dir) and ret
 
     print "* Check /var files"
     import md5sum_var

--- a/hironx_ros_bridge/robot/check/robot-system-check-base.py
+++ b/hironx_ros_bridge/robot/check/robot-system-check-base.py
@@ -8,6 +8,7 @@ from qnx_eth_check import *
 from hrpiob_check import *
 from md5sum_check import *
 
+
 class Logger(object):
     def __init__(self, filename="Default.log"):
         self.terminal = sys.stdout
@@ -107,12 +108,19 @@ try:
     print ""
     print "---"
     print ""
+    print "                              *******"
     print "Done all test, Result is ... ", ret
+    print "                              *******"
 
     if ret:
         print ""
         print "--- !!! CONGRATULATIONS !!! --- "
         print ""
+
+    # Version of Installability Checker. 
+    # TODO: Clarify versioning policy. As of now it corresponds to that of hironx_ros_bridge.
+    print('\tInstallability Checker version = 1.0.21')
+    print('\tFor any issue please report to TORK or https://github.com/start-jsk/rtmros_hironx/issues')
 
 except Exception, e:
     print "*** "

--- a/hironx_ros_bridge/robot/robot-system-check.sh
+++ b/hironx_ros_bridge/robot/robot-system-check.sh
@@ -50,7 +50,7 @@ getent ahosts $hostname || (echo -e "-- [ERROR] Could find IP address/Host name 
 echo ";; Copying check script to $userid@$hostname:$TMPDIR"
 ssh  $userid@$hostname "touch /opt/jsk/.checked"
 ssh  $userid@$hostname "mkdir -p /tmp/$TMPDIR"
-scp  ./check/robot-system-check-base $userid@$hostname:/tmp/$TMPDIR/
+scp  ./robot-system-check-base $userid@$hostname:/tmp/$TMPDIR/
 echo ";; Execute check scripts"
 ssh $userid@$hostname -t $commands 2>&1 | tee robot-system-check-$hostname.log
 

--- a/hironx_ros_bridge/robot/robot-system-check.sh
+++ b/hironx_ros_bridge/robot/robot-system-check.sh
@@ -44,15 +44,15 @@ echo ";; check Ubuntu version $DISTRO"
 
 ping -c1 $hostname || (echo -e "-- [ERROR] Could not connect to $hostname"; exit 1 ; )
 
-getent ahosts $hostname || (echo -e "-- [ERROR] Could find IP address/Host name for $hostname"; exit 1 ; )
+getent ahosts $hostname || (echo -e "-- [ERROR] Could not find IP address/Host name for $hostname"; exit 1 ; )
 
 
 echo ";; Copying check script to $userid@$hostname:$TMPDIR"
-ssh  $userid@$hostname "touch /opt/jsk/.checked"
 ssh  $userid@$hostname "mkdir -p /tmp/$TMPDIR"
 scp  ./robot-system-check-base $userid@$hostname:/tmp/$TMPDIR/
 echo ";; Execute check scripts"
 ssh $userid@$hostname -t $commands 2>&1 | tee robot-system-check-$hostname.log
+ssh  $userid@$hostname "touch /opt/jsk/.checked"
 
 echo -e ";;\n;;\n;; Done check scripts, please check robot-system-check-$hostname.log file\n;;\n;;\n"
 


### PR DESCRIPTION
Having the binary file at the same folder of the script that triggers it (`robot-system-check.sh`) makes these tools more portable.
