### PR TITLE
(robot qnx install) Adjusted to python 2.5 that is currently the default on QNX.

### DIFF
--- a/hironx_ros_bridge/robot/check/db_check.py
+++ b/hironx_ros_bridge/robot/check/db_check.py
@@ -9,7 +9,8 @@ def db_check(msg):
     print "\n* Saving DB..\n"
     try:
         r = requests.post(url, data=form_data, headers=user_agent)
-    except Exception as e:
+    # Using Python 2.5 style. See http://stackoverflow.com/questions/5119751/in-python-whats-the-difference-between-except-exception-as-e-and-except-exc
+    except Exception, e:
         print "".join(map(lambda s: hex(s), [ord(s) for s in e.message.message]))
         return False
     if not r.ok:


### PR DESCRIPTION
This avoids an `syntax error` returned  upon `make` on QNX.
