### PR TITLE
remove build_depend pr2_controllers_msgs

### DIFF
--- a/hironx_ros_bridge/package.xml
+++ b/hironx_ros_bridge/package.xml
@@ -16,7 +16,6 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>hrpsys_ros_bridge</build_depend> <!-- Needed to transitively depend on openhrp3. See https://github.com/start-jsk/rtmros_hironx/pull/30#commitcomment-5535604 -->
   <build_depend>mk</build_depend>
-  <build_depend>pr2_controllers_msgs</build_depend>
   <build_depend>roslib</build_depend>
   <build_depend>rosbash</build_depend>
   <build_depend>rosbuild</build_depend>
@@ -27,7 +26,6 @@
   <run_depend>gnuplot</run_depend>
   <run_depend>moveit_commander</run_depend>
   <run_depend>hrpsys_ros_bridge</run_depend>
-  <run_depend>pr2_controllers_msgs</run_depend>
   <run_depend>roslib</run_depend>
   <run_depend>rosbash</run_depend>
   <run_depend>rospy</run_depend>


### PR DESCRIPTION
which wrongly introduced https://github.com/start-jsk/rtmros_hironx/commit/970e98292d9d21c1f600ddb966c0aa8194d05837
