### PR TITLE
do not raise error when running component is not support the function

### DIFF
--- a/hironx_ros_bridge/test/test_hironx.py
+++ b/hironx_ros_bridge/test/test_hironx.py
@@ -22,6 +22,7 @@ import tempfile
 import math
 import random
 import numpy
+import re
 
 from rtm import connectPorts, disconnectPorts
 
@@ -583,8 +584,15 @@ class TestHiro(unittest.TestCase):
         self.robot.goInitial()
         posel1 = self.robot.getReferencePose('LARM_JOINT5')
         poser1 = self.robot.getReferencePose('RARM_JOINT5')
-        posel2 = self.robot.getReferencePose('LARM_JOINT5:WAIST')
-        poser2 = self.robot.getReferencePose('RARM_JOINT5:WAIST')
+        try:
+            posel2 = self.robot.getReferencePose('LARM_JOINT5:WAIST')
+            poser2 = self.robot.getReferencePose('RARM_JOINT5:WAIST')
+        except RuntimeError as e:
+            if re.match(r'frame_name \(.+\) is not supported', e.message):
+                print(e.message + "...this is expected so pass the test")
+                return True
+            else:
+                raise RuntimeError(e.message)
         print_pose("robot.getReferencePose('LARM_JOINT5')", posel1);
         print_pose("robot.getReferencePose('RARM_JOINT5')", poser1);
         print_pose("robot.getReferencePose('LARM_JOINT5:WAIST')", posel2);
@@ -627,8 +635,15 @@ class TestHiro(unittest.TestCase):
         self.robot.goInitial()
         posel1 = self.robot.getCurrentPose('LARM_JOINT5')
         poser1 = self.robot.getCurrentPose('RARM_JOINT5')
-        posel2 = self.robot.getCurrentPose('LARM_JOINT5:WAIST')
-        poser2 = self.robot.getCurrentPose('RARM_JOINT5:WAIST')
+        try:
+            posel2 = self.robot.getCurrentPose('LARM_JOINT5:WAIST')
+            poser2 = self.robot.getCurrentPose('RARM_JOINT5:WAIST')
+        except RuntimeError as e:
+            if re.match(r'frame_name \(.+\) is not supported', e.message):
+                print(e.message + "...this is expected so pass the test")
+                return True
+            else:
+                raise RuntimeError(e.message)
         print_pose("robot.getCurrentPose('LARM_JOINT5')", posel1);
         print_pose("robot.getCurrentPose('RARM_JOINT5')", poser1);
         print_pose("robot.getCurrentPose('LARM_JOINT5:WAIST')", posel2);


### PR DESCRIPTION
this is workaround for https://github.com/fkanehiro/hrpsys-base/pull/327#issuecomment-54598108
this assume hrpsys_config.py returns

```
            raise RuntimeError('frame_name ('+lname+') is not supported')
```

if it isnot supported (https://github.com/fkanehiro/hrpsys-base/pull/328)
