### PR TITLE
Add roslint. Code cleaned to pass roslint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
     - env: ROS_DISTRO=groovy ROSWS=rosws  BUILDER=rosbuild  USE_DEB=true
     - env: ROS_DISTRO=groovy ROSWS=rosws  BUILDER=rosbuild  USE_DEB=false
     - env: ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin    USE_DEB=true
+    - env: ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin    USE_DEB=false
 notifications:
   email:
     recipients:

--- a/hironx_ros_bridge/catkin.cmake
+++ b/hironx_ros_bridge/catkin.cmake
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(hironx_ros_bridge)
 
-find_package(catkin REQUIRED COMPONENTS hrpsys_ros_bridge pr2_controllers_msgs roslib rostest)
+find_package(catkin REQUIRED COMPONENTS hrpsys_ros_bridge pr2_controllers_msgs roslib roslint rostest)
 find_package(Boost REQUIRED COMPONENTS system)
 
 catkin_package(
@@ -105,3 +105,6 @@ install(DIRECTORY include/
 
 add_rostest(test/test-hironx.test)
 add_rostest(test/test-hironx-ros-bridge.test)
+
+roslint_python(scripts/hironx.py src/hironx_ros_bridge/hironx_client.py src/hironx_ros_bridge/ros_client.py src/hironx_ros_bridge/constant.py)
+roslint_cpp()

--- a/hironx_ros_bridge/include/ros_client.cpp
+++ b/hironx_ros_bridge/include/ros_client.cpp
@@ -1,3 +1,37 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2014, TORK (Tokyo Opensource Robotics Kyokai Association)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *  * Neither the name of JSK Lab, University of Tokyo. nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #ifndef ROS_CLIENT_HPP
 #define ROS_CLIENT_HPP
 
@@ -11,37 +45,41 @@
 #include <vector>
 #include <cmath>
 
-class ROS_Client {
+class ROS_Client
+{
   /*
-    This class:
+   This class:
 
-    - holds methods that are specific to Kawada Industries' dual-arm
-    robot called Hiro, via ROS.
-    - As of July 2014, this class is only intended to be used through HIRONX
-    class.
-  */
+   - holds methods that are specific to Kawada Industries' dual-arm
+   robot called Hiro, via ROS.
+   - As of July 2014, this class is only intended to be used through HIRONX
+   class.
+   */
 
-  //TODO: Address the following concern.
+  // TODO(@iory): Address the following concern.
   // This duplicates "Group" definition in HIRONX, which is bad.
   // Need to consider consolidating the definition either in hironx_ros_bridge
   // or somewhere in the upstream, e.g.:
   // https://github.com/fkanehiro/hrpsys-base/pull/253
 public:
-  typedef actionlib::SimpleActionClient< pr2_controllers_msgs::JointTrajectoryAction > TrajClient;
+  typedef actionlib::SimpleActionClient<pr2_controllers_msgs::JointTrajectoryAction> TrajClient;
 
   pr2_controllers_msgs::JointTrajectoryGoal goal;
 
-  ROS_Client():
-    GR_TORSO("torso"),GR_HEAD("head"),
-    GR_LARM("larm"),GR_RARM("rarm"),
-    MSG_ASK_ISSUEREPORT("Your report to https://github.com/start-jsk/rtmros_hironx/issues about the issue you are seeing is appreciated.")
-  {};
+  ROS_Client() :
+      GR_TORSO("torso"), GR_HEAD("head"), GR_LARM("larm"), GR_RARM("rarm"), MSG_ASK_ISSUEREPORT(
+          "Your report to https://github.com/start-jsk/rtmros_hironx/issues " +
+          "about the issue you are seeing is appreciated.")
+  {
+  }
 
-  explicit ROS_Client(std::vector<std::string> joingroups):
-    MSG_ASK_ISSUEREPORT("Your report to https://github.com/start-jsk/rtmros_hironx/issues about the issue you are seeing is appreciated.")
+  explicit ROS_Client(std::vector<std::string> joingroups) :
+      MSG_ASK_ISSUEREPORT(
+          "Your report to https://github.com/start-jsk/rtmros_hironx/issues " +
+          "about the issue you are seeing is appreciated.")
   {
     set_groupnames(joingroups);
-  };
+  }
 
   ROS_Client(const ROS_Client& obj)
   {
@@ -49,25 +87,27 @@ public:
     GR_HEAD = obj.GR_HEAD;
     GR_LARM = obj.GR_LARM;
     GR_RARM = obj.GR_RARM;
-  };
+  }
 
   ROS_Client& operator=(const ROS_Client& obj)
   {
-    GR_TORSO= obj.GR_TORSO;
+    GR_TORSO = obj.GR_TORSO;
     GR_HEAD = obj.GR_HEAD;
     GR_LARM = obj.GR_LARM;
     GR_RARM = obj.GR_RARM;
     return *this;
-  };
+  }
 
-  ~ROS_Client(){};
+  ~ROS_Client()
+  {
+  }
 
   void init_action_clients()
   {
     static TrajClient aclient_larm("/larm_controller/joint_trajectory_action", true);
     static TrajClient aclient_rarm("/rarm_controller/joint_trajectory_action", true);
     static TrajClient aclient_head("/head_controller/joint_trajectory_action", true);
-    static TrajClient aclient_torso("/torso_controller/joint_trajectory_action",true);
+    static TrajClient aclient_torso("/torso_controller/joint_trajectory_action", true);
 
     aclient_larm.waitForServer();
     ROS_INFO("ros_client; 1");
@@ -102,84 +142,87 @@ public:
     // Display Joint names
     ROS_INFO("\nJoint names;");
     std::cout << "Torso: [";
-    for(std::vector<std::string>::iterator name = goal_torso.trajectory.joint_names.begin();
+    for (std::vector<std::string>::iterator name = goal_torso.trajectory.joint_names.begin();
         name != goal_torso.trajectory.joint_names.end(); ++name)
       std::cout << *name << " ";
     std::cout << "]\nHead: [";
-    for(std::vector<std::string>::iterator name = goal_head.trajectory.joint_names.begin();
+    for (std::vector<std::string>::iterator name = goal_head.trajectory.joint_names.begin();
         name != goal_head.trajectory.joint_names.end(); ++name)
       std::cout << *name << " ";
     std::cout << "]\nL-Arm: [";
-    for(std::vector<std::string>::iterator name = goal_larm.trajectory.joint_names.begin();
+    for (std::vector<std::string>::iterator name = goal_larm.trajectory.joint_names.begin();
         name != goal_larm.trajectory.joint_names.end(); ++name)
       std::cout << *name << " ";
     std::cout << "]\nR-Arm: [";
-    for(std::vector<std::string>::iterator name = goal_rarm.trajectory.joint_names.begin();
+    for (std::vector<std::string>::iterator name = goal_rarm.trajectory.joint_names.begin();
         name != goal_rarm.trajectory.joint_names.end(); ++name)
-      std::cout << *name << " "; std::cout << "]" << std::endl;
+      std::cout << *name << " ";
+    std::cout << "]" << std::endl;
   }
 
-
   // Init positions are taken from HIRONX.
-  // TODO: Need to add factory position too that's so convenient when
+  // TODO(@iory): Need to add factory position too that's so convenient when
   // working with the manufacturer.
-  void go_init(double task_duration=7.0)
+  void go_init(double task_duration = 7.0)
   {
     ROS_INFO("*** go_init begins ***");
-    std::vector<double> POSITIONS_TORSO_DEG(1,0.0);
+    std::vector<double> POSITIONS_TORSO_DEG(1, 0.0);
     set_joint_angles_deg(GR_TORSO, POSITIONS_TORSO_DEG, task_duration);
 
-    std::vector<double> POSITIONS_HEAD_DEG(2,0.0);
+    std::vector<double> POSITIONS_HEAD_DEG(2, 0.0);
     set_joint_angles_deg(GR_HEAD, POSITIONS_HEAD_DEG, task_duration);
 
     std::vector<double> POSITIONS_LARM_DEG(6);
     POSITIONS_LARM_DEG[0] = 0.6;
     POSITIONS_LARM_DEG[1] = 0.0;
-    POSITIONS_LARM_DEG[2] =-100;
-    POSITIONS_LARM_DEG[3] =-15.2;
+    POSITIONS_LARM_DEG[2] = -100;
+    POSITIONS_LARM_DEG[3] = -15.2;
     POSITIONS_LARM_DEG[4] = 9.4;
-    POSITIONS_LARM_DEG[5] =-3.2;
+    POSITIONS_LARM_DEG[5] = -3.2;
     set_joint_angles_deg(GR_LARM, POSITIONS_LARM_DEG, task_duration);
 
     std::vector<double> POSITIONS_RARM_DEG(6);
-    POSITIONS_RARM_DEG[0] =-0.6;
-    POSITIONS_RARM_DEG[1] =   0;
-    POSITIONS_RARM_DEG[2] =-100;
-    POSITIONS_RARM_DEG[3] =15.2;
+    POSITIONS_RARM_DEG[0] = -0.6;
+    POSITIONS_RARM_DEG[1] = 0;
+    POSITIONS_RARM_DEG[2] = -100;
+    POSITIONS_RARM_DEG[3] = 15.2;
     POSITIONS_RARM_DEG[4] = 9.4;
     POSITIONS_RARM_DEG[5] = 3.2;
-    set_joint_angles_deg(GR_RARM, POSITIONS_RARM_DEG,task_duration, true);
+    set_joint_angles_deg(GR_RARM, POSITIONS_RARM_DEG, task_duration, true);
 
     ROS_INFO("*** go_init_ends ***");
   }
 
   // This method takes the angles(radian) and
   // changes the angle of the joints of the robot.
-  void set_joint_angles_rad(std::string groupname,
-			    std::vector<double> positions_radian,
-			    double duration=7.0,
-			    bool wait=false)
+  void set_joint_angles_rad(std::string groupname, std::vector<double> positions_radian, double duration = 7.0,
+                            bool wait = false)
   {
     TrajClient* action_client;
 
-    if(groupname == GR_TORSO){
+    if (groupname == GR_TORSO)
+    {
       action_client = new TrajClient("torso_controller/joint_trajectory_action", true);
       goal = goal_torso;
     }
-    else if(groupname == GR_HEAD){
+    else if (groupname == GR_HEAD)
+    {
       action_client = new TrajClient("head_controller/joint_trajectory_action", true);
       goal = goal_head;
     }
-    else if(groupname == GR_LARM){
-      action_client =  new TrajClient("larm_controller/joint_trajectory_action", true);
+    else if (groupname == GR_LARM)
+    {
+      action_client = new TrajClient("larm_controller/joint_trajectory_action", true);
       goal = goal_larm;
     }
-    else if(groupname == GR_RARM){
-      action_client =  new TrajClient("rarm_controller/joint_trajectory_action", true);
+    else if (groupname == GR_RARM)
+    {
+      action_client = new TrajClient("rarm_controller/joint_trajectory_action", true);
       goal = goal_rarm;
     }
 
-    try {
+    try
+    {
       trajectory_msgs::JointTrajectoryPoint pt;
       pt.positions = positions_radian;
       pt.time_from_start = ros::Duration(duration);
@@ -187,29 +230,28 @@ public:
       goal.trajectory.points.push_back(pt);
       goal.trajectory.header.stamp = ros::Time::now() + ros::Duration(duration);
       action_client->sendGoal(goal);
-      if(wait){
-	ROS_INFO("waiting......");
-	ROS_INFO("wait_for_result for the joint group %s = %d",
-		 groupname.c_str(), action_client->waitForResult());
+      if (wait)
+      {
+        ROS_INFO("waiting......");
+        ROS_INFO("wait_for_result for the joint group %s = %d", groupname.c_str(), action_client->waitForResult());
       }
     }
-    catch(const ros::Exception& e){
-      ROS_INFO("%s",e.what());
+    catch (const ros::Exception& e)
+    {
+      ROS_INFO("%s", e.what());
     }
-    catch( ... ){
+    catch (...)
+    {
       ROS_INFO("Exception");
     }
     delete action_client;
   }
 
-
   //  groupname: This should exist in groupnames.
-  void set_joint_angles_deg(std::string groupname,
-			    std::vector<double> positions_deg,
-			    double duration = 7.0,
-			    bool wait = false)
+  void set_joint_angles_deg(std::string groupname, std::vector<double> positions_deg, double duration = 7.0, bool wait =
+                                false)
   {
-    set_joint_angles_rad(groupname,to_rad_list(positions_deg),duration,wait);
+    set_joint_angles_rad(groupname, to_rad_list(positions_deg), duration, wait);
   }
 
 private:
@@ -226,25 +268,26 @@ private:
   pr2_controllers_msgs::JointTrajectoryGoal goal_torso;
 
   /*
-    param groupnames: List of the joint group names. Assumes to be in the
-    following order:
-    torso, head, right arm, left arm.
-    This current setting is derived from the order of
-    Groups argument in HIRONX class. If other groups
-    need to be defined in the future, this method may
-    need to be modified.
-  */
+   param groupnames: List of the joint group names. Assumes to be in the
+   following order:
+   torso, head, right arm, left arm.
+   This current setting is derived from the order of
+   Groups argument in HIRONX class. If other groups
+   need to be defined in the future, this method may
+   need to be modified.
+   */
   void set_groupnames(std::vector<std::string> groupnames)
   {
     // output group name
     ROS_INFO("set_groupnames");
-    for(std::vector<std::string>::iterator name = groupnames.begin(); name != groupnames.end(); ++name)
-      std::cout << *name << " "; std::cout << std::endl;
+    for (std::vector<std::string>::iterator name = groupnames.begin(); name != groupnames.end(); ++name)
+      std::cout << *name << " ";
+    std::cout << std::endl;
 
     GR_TORSO = groupnames[0];
-    GR_HEAD  = groupnames[1];
-    GR_RARM  = groupnames[2];
-    GR_LARM  = groupnames[3];
+    GR_HEAD = groupnames[1];
+    GR_RARM = groupnames[2];
+    GR_LARM = groupnames[3];
   }
 
   // This method change degree to radian.
@@ -253,14 +296,14 @@ private:
   {
     std::vector<double> list_rad;
     list_rad.reserve(list_degree.size());
-    for(std::vector<double>::iterator deg = list_degree.begin(); deg != list_degree.end();  ++deg){
+    for (std::vector<double>::iterator deg = list_degree.begin(); deg != list_degree.end(); ++deg)
+    {
       double rad = *deg * M_PI / 180.0;
       list_rad.push_back(rad);
       ROS_INFO("Position deg=%lf rad=%lf", *deg, rad);
     }
     return list_rad;
   }
-
 };
 
 #endif

--- a/hironx_ros_bridge/include/ros_client.cpp
+++ b/hironx_ros_bridge/include/ros_client.cpp
@@ -68,14 +68,14 @@ public:
 
   ROS_Client() :
       GR_TORSO("torso"), GR_HEAD("head"), GR_LARM("larm"), GR_RARM("rarm"), MSG_ASK_ISSUEREPORT(
-          "Your report to https://github.com/start-jsk/rtmros_hironx/issues " +
+          "Your report to https://github.com/start-jsk/rtmros_hironx/issues "
           "about the issue you are seeing is appreciated.")
   {
   }
 
   explicit ROS_Client(std::vector<std::string> joingroups) :
       MSG_ASK_ISSUEREPORT(
-          "Your report to https://github.com/start-jsk/rtmros_hironx/issues " +
+          "Your report to https://github.com/start-jsk/rtmros_hironx/issues "
           "about the issue you are seeing is appreciated.")
   {
     set_groupnames(joingroups);

--- a/hironx_ros_bridge/package.xml
+++ b/hironx_ros_bridge/package.xml
@@ -18,6 +18,7 @@
   <build_depend>mk</build_depend>
   <build_depend>pr2_controllers_msgs</build_depend>
   <build_depend>roslib</build_depend>
+  <build_depend>roslint</build_depend>
   <build_depend>rosbash</build_depend>
   <build_depend>rosbuild</build_depend>
   <build_depend>roslang</build_depend>

--- a/hironx_ros_bridge/robot/nitta/jr3_driver.cpp
+++ b/hironx_ros_bridge/robot/nitta/jr3_driver.cpp
@@ -7,6 +7,7 @@
  * Modified by Kei Okada, 2014
  */
 
+#include <algorithm>
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -21,50 +22,48 @@
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
-int io_read (resmgr_context_t * ctp, io_read_t * msg, RESMGR_OCB_T * ocb);	//
-static char *buffer = (char *) "Hello world\n";	//
+int io_read(resmgr_context_t * ctp, io_read_t * msg, RESMGR_OCB_T * ocb);
+static char *buffer = <char *>"Hello world\n";
 
-void wait_t (void);		// wait for 3 sec.
+void wait_t(void);  // wait for 3 sec.
 
 #include "QNX101/jr3pci3.idm"
 
-#define VENDORID	0x1762	/* Vendor ID of JR3 */
+#define VENDORID        0x1762  /* Vendor ID of JR3 */
 // #define DEVICEID     0x3114  /* for 4ch board */
 // #define DEVICEID     0x3113  /* for 3ch board */
-#define DEVICEID	0x3112	/* for 2ch board */
+#define DEVICEID        0x3112  /* for 2ch board */
 // #define DEVICEID     0x1111  /* for 1ch board */
 
-#define Jr3ResetAddr	0x18000
-#define Jr3NoAddrMask	0x40000
-#define Jr3DmAddrMask	0x6000
-unsigned long MappedAddress;
+#define Jr3ResetAddr  0x18000
+#define Jr3NoAddrMask 0x40000
+#define Jr3DmAddrMask 0x6000
+unsigned int64 MappedAddress;
 
 /* Convert a DSP bus address to a PCI bus address */
-#define ToJr3PciAddrH(addr)	(((int)(addr) << 2) + Jr3BaseAddressH)
-#define ToJr3PciAddrL(addr)	(((int)(addr) << 2) + Jr3BaseAddressL)
+#define ToJr3PciAddrH(addr) ((<int>(addr) << 2) + Jr3BaseAddressH)
+#define ToJr3PciAddrL(addr) ((<int>(addr) << 2) + Jr3BaseAddressL)
 
 /* Read and Write from the program memory */
-#define ReadJr3Pm(addr) 	(*(uint16_t volatile *)(ToJr3PciAddrH((addr))) << 8 |\
-				 *(uint8_t  volatile *)(ToJr3PciAddrL((addr))))
+#define ReadJr3Pm(addr) (*(uint16_t volatile *)(ToJr3PciAddrH((addr))) << 8 |\
+    *(uint8_t  volatile *)(ToJr3PciAddrL((addr))))
 
-#define WriteJr3Pm2(addr,data,data2)	(*(int volatile *)ToJr3PciAddrH((addr)) = (int)(data));(*(int volatile *)ToJr3PciAddrL((addr)) = (int)(data2))
+#define WriteJr3Pm2(addr, data, data2) (*<int volatile *>ToJr3PciAddrH((addr)) = <int>(data));
+(*<int volatile *>ToJr3PciAddrL((addr)) = <int>(data2))
 
-
-
-#define WriteJr3Pm(addr,data)		WriteJr3Pm2((addr),(data) >> 8, (data))
+#define WriteJr3Pm(addr, data) WriteJr3Pm2((addr), (data) >> 8, (data))
 
 /* Read and Write from the data memory using bus relative addressing */
-#define	ReadJr3Dm(addr)	(*(uint16_t volatile *)(ToJr3PciAddrH((addr))))
-#define WriteJr3Dm(addr,data)	*(int volatile *)(ToJr3PciAddrH((addr))) = (int)(data)
+#define ReadJr3Dm(addr) (*<uint16_t volatile *>(ToJr3PciAddrH((addr))))
+#define WriteJr3Dm(addr, data) *<int volatile *>(ToJr3PciAddrH((addr))) = <int>(data)
 
 /* Read and Write from the data memory using 0 relative addressing */
 #define ReadJr3(addr) (ReadJr3Dm((addr) | Jr3DmAddrMask))
-#define WriteJr3(addr,data) WriteJr3Dm((addr) | Jr3DmAddrMask,data)
+#define WriteJr3(addr, data) WriteJr3Dm((addr) | Jr3DmAddrMask, data)
 
-
-static resmgr_connect_funcs_t ConnectFuncs;	//
-static resmgr_io_funcs_t IoFuncs;	//
-static iofunc_attr_t IoFuncAttr;	//
+static resmgr_connect_funcs_t ConnectFuncs;
+static resmgr_io_funcs_t IoFuncs;
+static iofunc_attr_t IoFuncAttr;
 
 /* Jr3 Base address */
 volatile uint32_t Jr3BaseAddressH;
@@ -112,8 +111,6 @@ struct force_array
   int16_t dummy8;
 };
 
-
-
 struct six_axis_array
 {
   int16_t fx;
@@ -132,64 +129,57 @@ struct six_axis_array
 
 struct vect_bits
 {
-  uint8_t fx:1;
-  uint8_t fy:1;
-  uint8_t fz:1;
-  uint8_t mx:1;
-  uint8_t my:1;
-  uint8_t mz:1;
-  uint8_t changedV1:1;
-  uint8_t changedV2:1;
+  uint8_t fx :1;
+  uint8_t fy :1;
+  uint8_t fz :1;
+  uint8_t mx :1;
+  uint8_t my :1;
+  uint8_t mz :1;
+  uint8_t changedV1 :1;
+  uint8_t changedV2 :1;
   int16_t dummy;
 };
 
 struct warning_bits
 {
-  uint8_t fx_near_set:1;
-  uint8_t fy_near_set:1;
-  uint8_t fz_near_set:1;
-  uint8_t mx_near_set:1;
-  uint8_t my_near_set:1;
-  uint8_t mz_near_set:1;
-  uint8_t reserved:8;
-  //uint8_t        reserved : 10; // this will use 3 byte
+  uint8_t fx_near_set :1;
+  uint8_t fy_near_set :1;
+  uint8_t fz_near_set :1;
+  uint8_t mx_near_set :1;
+  uint8_t my_near_set :1;
+  uint8_t mz_near_set :1;
+  uint8_t reserved :8;
+  // uint8_t        reserved : 10;  // this will use 3 byte
   int16_t dummy;
 };
 
 struct error_bits
 {
-  uint8_t fx_sat:1;
-  uint8_t fy_sat:1;
-  uint8_t fz_sat:1;
-  uint8_t mx_sat:1;
-  uint8_t my_sat:1;
-  uint8_t mz_sat:1;
-  uint8_t researved:2;
-  //uint8_t       researved : 4; // this will use 3 byte
-  uint8_t memry_error:1;
-  uint8_t sensor_charge:1;
-  uint8_t system_busy:1;
-  uint8_t cal_crc_bad:1;
-  uint8_t watch_dog2:1;
-  uint8_t watch_dog:1;
+  uint8_t fx_sat :1;
+  uint8_t fy_sat :1;
+  uint8_t fz_sat :1;
+  uint8_t mx_sat :1;
+  uint8_t my_sat :1;
+  uint8_t mz_sat :1;
+  uint8_t researved :2;
+  // uint8_t       researved : 4;  // this will use 3 byte
+  uint8_t memry_error :1;
+  uint8_t sensor_charge :1;
+  uint8_t system_busy :1;
+  uint8_t cal_crc_bad :1;
+  uint8_t watch_dog2 :1;
+  uint8_t watch_dog :1;
   int16_t dummy1;
 };
 
-char *force_units_str[] =
-  { (char *) "pound, inch*pound, inch*1000",
-(char *) "Newton, Newton*meter*10, mm*10", (char *) "kilogram-force*10, kilogram-Force*cm, mm*10",
-(char *) "kilopound, kiloinch*pound, inch*1000" };
+char *force_units_str[] = {<char *>"pound, inch*pound, inch*1000", <char *>"Newton, Newton*meter*10, mm*10",
+                           <char *>"kilogram-force*10, kilogram-Force*cm, mm*10",
+                           <char *>"kilopound, kiloinch*pound, inch*1000"};
 
 enum force_units
 {
-  lbs_in_lbs_mils,
-  N_dNm_mm10,
-  kgf10_kgFcm_mm10,
-  klbs_kin_lbs_mils,
-  reserved_units_4,
-  reserved_units_5,
-  reserved_units_6,
-  reserved_units_7
+  lbs_in_lbs_mils, N_dNm_mm10, kgf10_kgFcm_mm10, klbs_kin_lbs_mils, reserved_units_4, reserved_units_5,
+  reserved_units_6, reserved_units_7
 };
 
 struct thresh_struct
@@ -233,122 +223,119 @@ struct transform
   links link[8];
 };
 
-
 struct force_sensor_data
 {
-  raw_channel raw_channels[16];	/* offset 0x0000 */
-  char copyright[0x18 * 4];	/* offset 0x0040 */
-  int16_t reserved1[0x08 * 2];	/* offset 0x0058 */
-  six_axis_array shunts;	/* offset 0x0060 */
-  int16_t reserved2[2];		/* offset 0x0066 */
+  raw_channel raw_channels[16]; /* offset 0x0000 */
+  char copyright[0x18 * 4]; /* offset 0x0040 */
+  int16_t reserved1[0x08 * 2]; /* offset 0x0058 */
+  six_axis_array shunts; /* offset 0x0060 */
+  int16_t reserved2[2]; /* offset 0x0066 */
   int16_t dummy1[2];
-  six_axis_array default_FS;	/* offset 0x0068 */
-  int16_t reserved3;		/* offset 0x006e */
+  six_axis_array default_FS; /* offset 0x0068 */
+  int16_t reserved3; /* offset 0x006e */
   int16_t dummy2;
-  int16_t load_envelope_num;	/* offset 0x006f */
+  int16_t load_envelope_num; /* offset 0x006f */
   int16_t dummy3;
-  six_axis_array min_full_scale;	/* offset 0x0070 */
-  int16_t reserved4;		/* offset 0x0076 */
+  six_axis_array min_full_scale; /* offset 0x0070 */
+  int16_t reserved4; /* offset 0x0076 */
   int16_t dummy4;
-  int16_t transform_num;	/* offset 0x0077 */
+  int16_t transform_num; /* offset 0x0077 */
   int16_t dummy5;
-  six_axis_array max_full_scale;	/* offset 0x0078 */
-  int16_t reserved5;		/* offset 0x007e */
+  six_axis_array max_full_scale; /* offset 0x0078 */
+  int16_t reserved5; /* offset 0x007e */
   int16_t dummy6;
-  int16_t peak_address;		/* offset 0x007f */
+  int16_t peak_address; /* offset 0x007f */
   int16_t dummy7;
-  force_array full_scale;	/* offset 0x0080 */
-  six_axis_array offsets;	/* offset 0x0088 */
-  int16_t offset_num;		/* offset 0x008e */
+  force_array full_scale; /* offset 0x0080 */
+  six_axis_array offsets; /* offset 0x0088 */
+  int16_t offset_num; /* offset 0x008e */
   int16_t dummy8;
-  vect_bits vect_axes;		/* offset 0x008f */
-  force_array filter0;		/* offset 0x0090 */
-  force_array filter1;		/* offset 0x0098 */
-  force_array filter2;		/* offset 0x00a0 */
-  force_array filter3;		/* offset 0x00a8 */
-  force_array filter4;		/* offset 0x00b0 */
-  force_array filter5;		/* offset 0x00b8 */
-  force_array filter6;		/* offset 0x00c0 */
-  force_array rate_data;	/* offset 0x00c8 */
-  force_array minimum_data;	/* offset 0x00d0 */
-  force_array maximum_data;	/* offset 0x00d8 */
-  int16_t near_sat_value;	/* offset 0x00e0 */
+  vect_bits vect_axes; /* offset 0x008f */
+  force_array filter0; /* offset 0x0090 */
+  force_array filter1; /* offset 0x0098 */
+  force_array filter2; /* offset 0x00a0 */
+  force_array filter3; /* offset 0x00a8 */
+  force_array filter4; /* offset 0x00b0 */
+  force_array filter5; /* offset 0x00b8 */
+  force_array filter6; /* offset 0x00c0 */
+  force_array rate_data; /* offset 0x00c8 */
+  force_array minimum_data; /* offset 0x00d0 */
+  force_array maximum_data; /* offset 0x00d8 */
+  int16_t near_sat_value; /* offset 0x00e0 */
   int16_t dummy9;
-  int16_t sat_value;		/* offset 0x00e1 */
+  int16_t sat_value; /* offset 0x00e1 */
   int16_t dummy10;
-  int16_t rate_address;		/* offset 0x00e2 */
+  int16_t rate_address; /* offset 0x00e2 */
   int16_t dummy11;
-  uint16_t rate_divisor;	/* offset 0x00e3 */
+  uint16_t rate_divisor; /* offset 0x00e3 */
   uint16_t dummy12;
-  uint16_t rate_count;		/* offset 0x00e4 */
+  uint16_t rate_count; /* offset 0x00e4 */
   uint16_t dummy13;
-  int16_t command_word2;	/* offset 0x00e5 */
+  int16_t command_word2; /* offset 0x00e5 */
   int16_t dummy14;
-  int16_t command_word1;	/* offset 0x00e6 */
+  int16_t command_word1; /* offset 0x00e6 */
   int16_t dummy15;
-  int16_t command_word0;	/* offset 0x00e7 */
+  int16_t command_word0; /* offset 0x00e7 */
   uint16_t dummy16;
-  uint16_t count1;		/* offset 0x00e8 */
+  uint16_t count1; /* offset 0x00e8 */
   uint16_t dummy17;
-  uint16_t count2;		/* offset 0x00e9 */
+  uint16_t count2; /* offset 0x00e9 */
   uint16_t dummy18;
-  uint16_t count3;		/* offset 0x00ea */
+  uint16_t count3; /* offset 0x00ea */
   uint16_t dummy19;
-  uint16_t count4;		/* offset 0x00eb */
+  uint16_t count4; /* offset 0x00eb */
   uint16_t dummy20;
-  uint16_t count5;		/* offset 0x00ec */
+  uint16_t count5; /* offset 0x00ec */
   uint16_t dummy21;
-  uint16_t count6;		/* offset 0x00ed */
+  uint16_t count6; /* offset 0x00ed */
   uint16_t dummy22;
-  uint16_t error_count;		/* offset 0x00ee */
+  uint16_t error_count; /* offset 0x00ee */
   uint16_t dummy23;
-  uint16_t count_x;		/* offset 0x00ef */
+  uint16_t count_x; /* offset 0x00ef */
   uint16_t dummy24;
-  warning_bits warnings;	/* offset 0x00f0 */
-  error_bits errors;		/* offset 0x00f1 */
-  int16_t threshold_bits;	/* offset 0x00f2 */
+  warning_bits warnings; /* offset 0x00f0 */
+  error_bits errors; /* offset 0x00f1 */
+  int16_t threshold_bits; /* offset 0x00f2 */
   int16_t dummy25;
-  int16_t last_crc;		/* offset 0x00f3 */
+  int16_t last_crc; /* offset 0x00f3 */
   int16_t dummy26;
-  int16_t eeprom_ver_no;	/* offset 0x00f4 */
+  int16_t eeprom_ver_no; /* offset 0x00f4 */
   int16_t dummy27;
-  int16_t software_ver_no;	/* offset 0x00f5 */
+  int16_t software_ver_no; /* offset 0x00f5 */
   int16_t dummy28;
-  int16_t software_day;		/* offset 0x00f6 */
+  int16_t software_day; /* offset 0x00f6 */
   int16_t dummy29;
-  int16_t software_year;	/* offset 0x00f7 */
+  int16_t software_year; /* offset 0x00f7 */
   int16_t dummy30;
-  uint16_t serial_no;		/* offset 0x00f8 */
+  uint16_t serial_no; /* offset 0x00f8 */
   uint16_t dummy31;
-  uint16_t model_no;		/* offset 0x00f9 */
+  uint16_t model_no; /* offset 0x00f9 */
   uint16_t dummy32;
-  int16_t cal_day;		/* offset 0x00fa */
+  int16_t cal_day; /* offset 0x00fa */
   int16_t dummy33;
-  int16_t cal_year;		/* offset 0x00fb */
+  int16_t cal_year; /* offset 0x00fb */
   int16_t dummy34;
-  force_units units;		/* offset 0x00fc */
-  int16_t bit;			/* offset 0x00fd */
+  force_units units; /* offset 0x00fc */
+  int16_t bit; /* offset 0x00fd */
   int16_t dummy35;
-  int16_t channels;		/* offset 0x00fe */
+  int16_t channels; /* offset 0x00fe */
   int16_t dummy36;
-  int16_t thickness;		/* offset 0x00ff */
+  int16_t thickness; /* offset 0x00ff */
   int16_t dummy37;
-  le_struct load_envelopes[0x10];	/* offset 0x0100 */
-  transform transforms[0x10];	/* offset 0x0200 */
+  le_struct load_envelopes[0x10]; /* offset 0x0100 */
+  transform transforms[0x10]; /* offset 0x0200 */
 };
-
 
 typedef struct
 {
   uint16_t msg_no;
   char msg_data[255];
-} server_msg_t;
+}
+server_msg_t;
 
-
-int
-download (unsigned int base0, unsigned int base1)
+int download(unsigned int base0, unsigned int base1)
 {
-  printf ("Download %x %x\n", base0, base1);
+  printf("Download %x %x\n", base0, base1);
 
   int count;
   int index = 0;
@@ -363,149 +350,130 @@ download (unsigned int base0, unsigned int base1)
 
   /* Read in file while the count is no 0xffff */
   while (count != 0xffff)
+  {
+    int addr;
+
+    /* After the count is the address */
+    addr = dsp[index++];
+
+    /* loop count times and write the data to the dsp memory */
+    while (count > 0)
     {
-      int addr;
+      /* Check to see if this is data memory or program memory */
+      if (addr & 0x4000)
+      {
+        int data = 0;
 
-      /* After the count is the address */
-      addr = dsp[index++];
+        /* Data memory is 16 bits and is on one line */
+        data = dsp[index++];
+        WriteJr3Dm(addr, data);
+        count--;
+        if (data != ReadJr3Dm(addr))
+        {
+          printf("data addr: %4.4x out: %4.4x in: %4.4x\n", addr, data, ReadJr3Dm(addr));
+        }
+      }
+      else
+      {
+        int data, data2;
+        int data3;
 
-      /* loop count times and write the data to the dsp memory */
-      while (count > 0)
-	{
-	  /* Check to see if this is data memory or program memory */
-	  if (addr & 0x4000)
-	    {
-	      int data = 0;
+        /* Program memory is 24 bits and is on two lines */
+        data = dsp[index++];
+        data2 = dsp[index++];
+        WriteJr3Pm2(addr, data, data2);
+        count -= 2;
 
-	      /* Data memory is 16 bits and is on one line */
-	      data = dsp[index++];
-	      WriteJr3Dm (addr, data);
-	      count--;
-	      if (data != ReadJr3Dm (addr))
-		{
-		  printf ("data addr: %4.4x out: %4.4x in: %4.4x\n", addr,
-			  data, ReadJr3Dm (addr));
-		}
-	    }
-	  else
-	    {
-	      int data, data2;
-	      int data3;
-
-
-	      /* Program memory is 24 bits and is on two lines */
-	      data = dsp[index++];
-	      data2 = dsp[index++];
-	      WriteJr3Pm2 (addr, data, data2);
-	      count -= 2;
-
-	      /* Verify the write */
-	      if (((data << 8) | (data2 & 0xff)) !=
-		  (data3 = ReadJr3Pm (addr)))
-		{
-		  //      printf("pro addr: %4.4x out: %6.6x in: %6.6x\n", addr, ((data << 8)|(data2 & 0xff)), /* ReadJr3Pm(addr) */ data3);
-		}
-	    }
-	  addr++;
-	}
-      count = dsp[index++];
+        /* Verify the write */
+        if (((data << 8) | (data2 & 0xff)) != (data3 = ReadJr3Pm(addr)))
+        {
+          //      printf("pro addr: %4.4x out: %6.6x in: %6.6x\n", addr,
+          //             ((data << 8)|(data2 & 0xff)), /* ReadJr3Pm(addr) */ data3);
+        }
+      }
+      addr++;
     }
-
+    count = dsp[index++];
+  }
 
   return 0;
-
 }
 
-void
-get_force_sensor_info (force_sensor_data * data, char *msg)
+void get_force_sensor_info(force_sensor_data * data, char *msg)
 {
-  struct tm t1, *soft_day, *cal_day;;
+  struct tm t1, *soft_day, *cal_day;
   time_t t2;
   t1.tm_sec = t1.tm_min = t1.tm_hour = 0;
   t1.tm_isdst = -1;
   t1.tm_mon = 0;
   t1.tm_year = data->software_year - 1900;
   t1.tm_mday = data->software_day;
-  t2 = mktime (&t1);
-  soft_day = localtime (&t2);
+  t2 = mktime(&t1);
+  soft_day = localtime_r(&t2);
   t1.tm_sec = t1.tm_min = t1.tm_hour = 0;
   t1.tm_isdst = -1;
   t1.tm_mon = 0;
   t1.tm_year = data->cal_year - 1900;
   t1.tm_mday = data->cal_day;
-  t2 = mktime (&t1);
-  cal_day = localtime (&t2);
-  snprintf (msg, 128,
-	    "rom # %d, soft # %d, %d/%d/%d\n"
-	    "serial # %d, model # %d, cal day %d/%d/%d\n"
-	    "%s, %d bits, %d ch\n"
-	    "(C) %c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c\n\n",
-	    data->eeprom_ver_no, data->software_ver_no, soft_day->tm_mday,
-	    soft_day->tm_mon + 1, soft_day->tm_year + 1900, data->serial_no,
-	    data->model_no, cal_day->tm_mday, cal_day->tm_mon + 1,
-	    cal_day->tm_year + 1900, force_units_str[1], data->bit,
-	    data->channels, data->copyright[0 * 4 + 1],
-	    data->copyright[1 * 4 + 1], data->copyright[2 * 4 + 1],
-	    data->copyright[3 * 4 + 1], data->copyright[4 * 4 + 1],
-	    data->copyright[5 * 4 + 1], data->copyright[6 * 4 + 1],
-	    data->copyright[7 * 4 + 1], data->copyright[8 * 4 + 1],
-	    data->copyright[9 * 4 + 1], data->copyright[10 * 4 + 1],
-	    data->copyright[11 * 4 + 1], data->copyright[12 * 4 + 1],
-	    data->copyright[13 * 4 + 1], data->copyright[14 * 4 + 1],
-	    data->copyright[15 * 4 + 1], data->copyright[16 * 4 + 1],
-	    data->copyright[17 * 4 + 1], data->copyright[18 * 4 + 1],
-	    data->copyright[19 * 4 + 1], data->copyright[20 * 4 + 1],
-	    data->copyright[21 * 4 + 1], data->copyright[22 * 4 + 1],
-	    data->copyright[23 * 4 + 1]);
+  t2 = mktime(&t1);
+  cal_day = localtime_r(&t2);
+  snprintf(msg, sizeof(msg), "rom # %d, soft # %d, %d/%d/%d\n"
+           "serial # %d, model # %d, cal day %d/%d/%d\n"
+           "%s, %d bits, %d ch\n"
+           "(C) %c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c\n\n",
+           data->eeprom_ver_no, data->software_ver_no, soft_day->tm_mday, soft_day->tm_mon + 1,
+           soft_day->tm_year + 1900, data->serial_no, data->model_no, cal_day->tm_mday, cal_day->tm_mon + 1,
+           cal_day->tm_year + 1900, force_units_str[1], data->bit, data->channels, data->copyright[0 * 4 + 1],
+           data->copyright[1 * 4 + 1], data->copyright[2 * 4 + 1], data->copyright[3 * 4 + 1],
+           data->copyright[4 * 4 + 1], data->copyright[5 * 4 + 1], data->copyright[6 * 4 + 1],
+           data->copyright[7 * 4 + 1], data->copyright[8 * 4 + 1], data->copyright[9 * 4 + 1],
+           data->copyright[10 * 4 + 1], data->copyright[11 * 4 + 1], data->copyright[12 * 4 + 1],
+           data->copyright[13 * 4 + 1], data->copyright[14 * 4 + 1], data->copyright[15 * 4 + 1],
+           data->copyright[16 * 4 + 1], data->copyright[17 * 4 + 1], data->copyright[18 * 4 + 1],
+           data->copyright[19 * 4 + 1], data->copyright[20 * 4 + 1], data->copyright[21 * 4 + 1],
+           data->copyright[22 * 4 + 1], data->copyright[23 * 4 + 1]);
 }
 
-
-
-int
-message_callback (message_context_t * ctp, int type, unsigned flags,
-		  void *handle)
+int message_callback(message_context_t * ctp, int type, unsigned flags, void *handle)
 {
   server_msg_t *msg;
   int num;
   char msg_reply[255];
 
   /* cast a pointer to the message data */
-  msg = (server_msg_t *) ctp->msg;
+  msg = <server_msg_t *>ctp->msg;
 
   /* Print out some usefull information on the message */
-  //printf( "\n\nServer Got Message:\n" );
-  //printf( "  type: %d\n" , type );
-  //printf( "  data: %s\n\n", msg->msg_data );
-
+  // printf( "\n\nServer Got Message:\n" );
+  // printf( "  type: %d\n" , type );
+  // printf( "  data: %s\n\n", msg->msg_data );
   force_sensor_data *data_0;
   force_sensor_data *data_1;
-  data_0 = (force_sensor_data *) (Jr3BaseAddress0H + (Jr3DmAddrMask << 2));
-  data_1 = (force_sensor_data *) (Jr3BaseAddress1H + (Jr3DmAddrMask << 2));
+  data_0 = <force_sensor_data *>(Jr3BaseAddress0H + (Jr3DmAddrMask << 2));
+  data_1 = <force_sensor_data *>(Jr3BaseAddress1H + (Jr3DmAddrMask << 2));
 
   /* Build the reply message */
   num = type - _IO_MAX;
   switch (num)
+  {
+    case 1:  // get data
     {
-    case 1:			// get data
-      {
-	float tmp[12] = {
-	  -1.0 * (float) data_0->filter0.fx / (float) data_0->full_scale.fx,
-	  -1.0 * (float) data_0->filter0.fy / (float) data_0->full_scale.fy,
-	  -1.0 * (float) data_0->filter0.fz / (float) data_0->full_scale.fz,
-	  -1.0 * (float) data_0->filter0.mx / (float) data_0->full_scale.mx * 0.1, // Newton*meter*10
-	  -1.0 * (float) data_0->filter0.my / (float) data_0->full_scale.my * 0.1,
-	  -1.0 * (float) data_0->filter0.mz / (float) data_0->full_scale.mz * 0.1,
-	  -1.0 * (float) data_1->filter0.fx / (float) data_1->full_scale.fx,
-	  -1.0 * (float) data_1->filter0.fy / (float) data_1->full_scale.fy,
-	  -1.0 * (float) data_1->filter0.fz / (float) data_1->full_scale.fz,
-	  -1.0 * (float) data_1->filter0.mx / (float) data_1->full_scale.mx * 0.1,
-	  -1.0 * (float) data_1->filter0.my / (float) data_1->full_scale.my * 0.1,
-	  -1.0 * (float) data_1->filter0.mz / (float) data_1->full_scale.mz * 0.1
-	};
-	memcpy (msg_reply, tmp, sizeof (float) * 12);
-      }
+      float tmp[12] = {-1.0 * <float>data_0->filter0.fx / <float>data_0->full_scale.fx, -1.0 * <float>data_0->filter0.fy
+                           / <float>data_0->full_scale.fy,
+                       -1.0 * <float>data_0->filter0.fz / <float>data_0->full_scale.fz, -1.0 * <float>data_0->filter0.mx
+                           / <float>data_0->full_scale.mx * 0.1,  // Newton*meter*10
+                       -1.0 * <float>data_0->filter0.my / <float>data_0->full_scale.my * 0.1, -1.0
+                           * <float>data_0->filter0.mz / <float>data_0->full_scale.mz * 0.1,
+                       -1.0 * <float>data_1->filter0.fx / <float>data_1->full_scale.fx, -1.0 * <float>data_1->filter0.fy
+                           / <float>data_1->full_scale.fy,
+                       -1.0 * <float>data_1->filter0.fz / <float>data_1->full_scale.fz, -1.0 * <float>data_1->filter0.mx
+                           / <float>data_1->full_scale.mx * 0.1,
+                       -1.0 * <float>data_1->filter0.my / <float>data_1->full_scale.my * 0.1, -1.0
+                           * <float>data_1->filter0.mz / <float>data_1->full_scale.mz * 0.1};
+      memcpy(msg_reply, tmp, sizeof(float) * 12);
+    }
       break;
-    case 2:			// update offset
+    case 2:  // update offset
       data_0->offsets.fx += data_0->filter0.fx;
       data_0->offsets.fy += data_0->filter0.fy;
       data_0->offsets.fz += data_0->filter0.fz;
@@ -519,23 +487,20 @@ message_callback (message_context_t * ctp, int type, unsigned flags,
       data_1->offsets.my += data_1->filter0.my;
       data_1->offsets.mz += data_1->filter0.mz;
       break;
-    case 3:			// set filter
+    case 3:  // set filter
       break;
-    case 4:			// get data
-      get_force_sensor_info (data_0, msg_reply);
-      get_force_sensor_info (data_1, msg_reply + strlen (msg_reply));
+    case 4:  // get data
+      get_force_sensor_info(data_0, msg_reply);
+      get_force_sensor_info(data_1, msg_reply + strlen(msg_reply));
       break;
-    }
+  }
 
   /* Send a reply to the waiting (blocked) client */
-  MsgReply (ctp->rcvid, EOK, msg_reply, 256);
+  MsgReply(ctp->rcvid, EOK, msg_reply, 256);
   return 0;
 }
 
-
-
-int
-main (int argc, char **argv)
+int main(int argc, char **argv)
 {
   resmgr_attr_t resmgr_attr;
   message_attr_t message_attr;
@@ -544,34 +509,32 @@ main (int argc, char **argv)
   int resmgr_id, message_id;
 
   /* Create the Dispatch Interface */
-  dpp = dispatch_create ();
+  dpp = dispatch_create();
   if (dpp == NULL)
-    {
-      fprintf (stderr, "dispatch_create() failed: %s\n", strerror (errno));
-      return EXIT_FAILURE;
-    }
+  {
+    fprintf(stderr, "dispatch_create() failed: %s\n", strerror(errno));
+    return EXIT_FAILURE;
+  }
 
-  memset (&resmgr_attr, 0, sizeof (resmgr_attr));
+  memset(&resmgr_attr, 0, sizeof(resmgr_attr));
   resmgr_attr.nparts_max = 1;
   resmgr_attr.msg_max_size = 2048;
 
   /* Setup the default I/O functions to handle open/read/write/... */
-  iofunc_func_init (_RESMGR_CONNECT_NFUNCS, &ConnectFuncs,
-		    _RESMGR_IO_NFUNCS, &IoFuncs);
+  iofunc_func_init(_RESMGR_CONNECT_NFUNCS, &ConnectFuncs, _RESMGR_IO_NFUNCS, &IoFuncs);
 
   IoFuncs.read = io_read;
 
   /* Setup the attribute for the entry in the filesystem */
-  iofunc_attr_init (&IoFuncAttr, S_IFNAM | 0666, 0, 0);
-  IoFuncAttr.nbytes = strlen (buffer) + 1;	//
+  iofunc_attr_init(&IoFuncAttr, S_IFNAM | 0666, 0, 0);
+  IoFuncAttr.nbytes = strlen(buffer) + 1;
 
-  resmgr_id = resmgr_attach (dpp, &resmgr_attr, "/dev/jr3q", _FTYPE_ANY,
-			     0, &ConnectFuncs, &IoFuncs, &IoFuncAttr);
+  resmgr_id = resmgr_attach(dpp, &resmgr_attr, "/dev/jr3q", _FTYPE_ANY, 0, &ConnectFuncs, &IoFuncs, &IoFuncAttr);
   if (resmgr_id == -1)
-    {
-      fprintf (stderr, "resmgr_attach() failed: %s\n", strerror (errno));
-      return EXIT_FAILURE;
-    }
+  {
+    fprintf(stderr, "resmgr_attach() failed: %s\n", strerror(errno));
+    return EXIT_FAILURE;
+  }
 
   /* Setup PCI */
   unsigned int flags = 0;
@@ -583,125 +546,105 @@ main (int argc, char **argv)
   void *bufptr;
   unsigned int addr;
 
-  pci_attach (flags);
-  result = pci_present (&lastbus, &version, &hardware);
+  pci_attach(flags);
+  result = pci_present(&lastbus, &version, &hardware);
   if (result == -1)
-    {
-      printf ("PCI BIOS not present!\n");
-    }
+  {
+    printf("PCI BIOS not present!\n");
+  }
   devid = DEVICEID;
   venid = VENDORID;
-  result = pci_find_device (devid, venid, index, &bus, &function);
-  printf ("result PCI %d\n", result);
-  printf ("bus %d\n", bus);
-  printf ("function %d\n", function);
-  pci_read_config_bus (bus, function, 0x10, 1, sizeof (unsigned int), bufptr);
+  result = pci_find_device(devid, venid, index, &bus, &function);
+  printf("result PCI %d\n", result);
+  printf("bus %d\n", bus);
+  printf("function %d\n", function);
+  pci_read_config_bus(bus, function, 0x10, 1, sizeof(unsigned int), bufptr);
 
-  address0 = *(unsigned int *) bufptr;
-  buffer = (char *) bufptr;
-  printf ("Board addr 0x%x\n", *(unsigned int *) buffer);
+  address0 = *<unsigned int *>bufptr;
+  buffer = <char *>bufptr;
+  printf("Board addr 0x%x\n", *(unsigned int *)buffer);
 
-  Jr3BaseAddress0H =
-    (volatile uint32_t) mmap_device_memory (NULL, 0x100000,
-					    PROT_READ | PROT_WRITE |
-					    PROT_NOCACHE, 0, address0);
-  Jr3BaseAddress0L =
-    (volatile uint32_t) mmap_device_memory (NULL, 0x100000,
-					    PROT_READ | PROT_WRITE |
-					    PROT_NOCACHE, 0,
-					    address0 + Jr3NoAddrMask);
-  Jr3BaseAddressH =
-    (volatile uint32_t) mmap_device_memory (NULL, 0x100000,
-					    PROT_READ | PROT_WRITE |
-					    PROT_NOCACHE, 0, address0);
-  WriteJr3Dm (Jr3ResetAddr, 0);	// Reset DSP       
-  wait_t ();
-  download (Jr3BaseAddress0H, Jr3BaseAddress0L);
-  wait_t ();
+  Jr3BaseAddress0H = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ | PROT_WRITE | PROT_NOCACHE, 0,
+                                                           address0);
+  Jr3BaseAddress0L = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ | PROT_WRITE | PROT_NOCACHE, 0,
+                                                           address0 + Jr3NoAddrMask);
+  Jr3BaseAddressH = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ | PROT_WRITE | PROT_NOCACHE, 0,
+                                                          address0);
+  WriteJr3Dm(Jr3ResetAddr, 0);  // Reset DSP
+  wait_t();
+  download(Jr3BaseAddress0H, Jr3BaseAddress0L);
+  wait_t();
 
-  Jr3BaseAddress1H =
-    (volatile uint32_t) mmap_device_memory (NULL, 0x100000,
-					    PROT_READ | PROT_WRITE |
-					    PROT_NOCACHE, 0,
-					    address0 + 0x80000);
-  Jr3BaseAddress1L =
-    (volatile uint32_t) mmap_device_memory (NULL, 0x100000,
-					    PROT_READ | PROT_WRITE |
-					    PROT_NOCACHE, 0,
-					    address0 + 0x80000 +
-					    Jr3NoAddrMask);
-  download (Jr3BaseAddress1H, Jr3BaseAddress1L);
-  wait_t ();
-/*
-			Jr3BaseAddress2H = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ|PROT_WRITE|PROT_NOCACHE, 0, address0 + 0x100000); 
-			Jr3BaseAddress2L = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ|PROT_WRITE|PROT_NOCACHE, 0, address0 + 0x100000 + Jr3NoAddrMask); 
-			download(Jr3BaseAddress2H, Jr3BaseAddress2L);
-			wait_t();
+  Jr3BaseAddress1H = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ | PROT_WRITE | PROT_NOCACHE, 0,
+                                                           address0 + 0x80000);
+  Jr3BaseAddress1L = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ | PROT_WRITE | PROT_NOCACHE, 0,
+                                                           address0 + 0x80000 +
+                                                           Jr3NoAddrMask);
+  download(Jr3BaseAddress1H, Jr3BaseAddress1L);
+  wait_t();
+  /*
+   Jr3BaseAddress2H = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ|PROT_WRITE|PROT_NOCACHE, 0, address0 + 0x100000);
+   Jr3BaseAddress2L = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ|PROT_WRITE|PROT_NOCACHE, 0, address0 + 0x100000 + Jr3NoAddrMask);
+   download(Jr3BaseAddress2H, Jr3BaseAddress2L);
+   wait_t();
 
-			Jr3BaseAddress3H = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ|PROT_WRITE|PROT_NOCACHE, 0, address0 + 0x180000); 
-			Jr3BaseAddress3L = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ|PROT_WRITE|PROT_NOCACHE, 0, address0 + 0x180000 + Jr3NoAddrMask); 
-			download(Jr3BaseAddress3H, Jr3BaseAddress3L);
-			wait_t();
-*/
+   Jr3BaseAddress3H = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ|PROT_WRITE|PROT_NOCACHE, 0, address0 + 0x180000);
+   Jr3BaseAddress3L = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ|PROT_WRITE|PROT_NOCACHE, 0, address0 + 0x180000 + Jr3NoAddrMask);
+   download(Jr3BaseAddress3H, Jr3BaseAddress3L);
+   wait_t();
+   */
 
-  //reset
-  *(uint16_t *) (Jr3BaseAddress0H + ((0x0200 | Jr3DmAddrMask) << 2)) =
-    (uint16_t) 0;
-  *(uint16_t *) (Jr3BaseAddress0H + ((0x00e7 | Jr3DmAddrMask) << 2)) =
-    (uint16_t) 0x0500;
-
+  // reset
+  *<uint16_t *>(Jr3BaseAddress0H + ((0x0200 | Jr3DmAddrMask) << 2)) = <uint16_t *>0;
+  *<uint16_t *>(Jr3BaseAddress0H + ((0x00e7 | Jr3DmAddrMask) << 2)) = <uint16_t *>0x0500;
 
   /* Setup our message callback */
-  memset (&message_attr, 0, sizeof (message_attr));
+  memset(&message_attr, 0, sizeof(message_attr));
   message_attr.nparts_max = 1;
   message_attr.msg_max_size = 4096;
 
   /* Attach a callback (handler) for two message types */
-  message_id = message_attach (dpp, &message_attr, _IO_MAX + 1,
-			       _IO_MAX + 10, message_callback, NULL);
+  message_id = message_attach(dpp, &message_attr, _IO_MAX + 1, _IO_MAX + 10, message_callback, NULL);
   if (message_id == -1)
-    {
-      fprintf (stderr, "message_attach() failed: %s\n", strerror (errno));
-      return EXIT_FAILURE;
-    }
+  {
+    fprintf(stderr, "message_attach() failed: %s\n", strerror(errno));
+    return EXIT_FAILURE;
+  }
 
   /* Setup a context for the dispatch layer to use */
-  ctp = dispatch_context_alloc (dpp);
+  ctp = dispatch_context_alloc(dpp);
   if (ctp == NULL)
-    {
-      fprintf (stderr, "dispatch_context_alloc() failed: %s\n",
-	       strerror (errno));
-      return EXIT_FAILURE;
-    }
+  {
+    fprintf(stderr, "dispatch_context_alloc() failed: %s\n", strerror(errno));
+    return EXIT_FAILURE;
+  }
 
   /* The "Data Pump" - get and process messages */
   while (1)
+  {
+    ctp_ret = dispatch_block(ctp);
+    if (ctp_ret)
     {
-      ctp_ret = dispatch_block (ctp);
-      if (ctp_ret)
-	{
-	  dispatch_handler (ctp);
-	}
-      else
-	{
-	  fprintf (stderr, "dispatch_block() failed: %s\n", strerror (errno));
-	  return EXIT_FAILURE;
-	}
+      dispatch_handler(ctp);
     }
+    else
+    {
+      fprintf(stderr, "dispatch_block() failed: %s\n", strerror(errno));
+      return EXIT_FAILURE;
+    }
+  }
 
   return EXIT_SUCCESS;
 }
 
-
-int
-io_read (resmgr_context_t * ctp, io_read_t * msg, RESMGR_OCB_T * ocb)
+int io_read(resmgr_context_t * ctp, io_read_t * msg, RESMGR_OCB_T * ocb)
 {
   int nleft;
   int nbytes;
   int nparts;
   int status;
 
-  if ((status = iofunc_read_verify (ctp, msg, ocb, NULL)) != EOK)
+  if ((status = iofunc_read_verify(ctp, msg, ocb, NULL)) != EOK)
     return (status);
 
   if ((msg->i.xtype & _IO_XTYPE_MASK) != _IO_XTYPE_NONE)
@@ -715,56 +658,54 @@ io_read (resmgr_context_t * ctp, io_read_t * msg, RESMGR_OCB_T * ocb)
    */
 
   nleft = ocb->attr->nbytes - ocb->offset;
-  nbytes = min (msg->i.nbytes, nleft);
+  nbytes = min(msg->i.nbytes, nleft);
 
   if (nbytes > 0)
-    {
-      /* set up the return data IOV */
-      SETIOV (ctp->iov, buffer + ocb->offset, nbytes);
+  {
+    /* set up the return data IOV */
+    SETIOV(ctp->iov, buffer + ocb->offset, nbytes);
 
-      /* set up the number of bytes (returned by client's read()) */
-      _IO_SET_READ_NBYTES (ctp, nbytes);
+    /* set up the number of bytes (returned by client's read()) */
+    _IO_SET_READ_NBYTES(ctp, nbytes);
 
-      /*
-       * advance the offset by the number of bytes
-       * returned to the client.
-       */
+    /*
+     * advance the offset by the number of bytes
+     * returned to the client.
+     */
 
-      ocb->offset += nbytes;
-      nparts = 1;
-    }
+    ocb->offset += nbytes;
+    nparts = 1;
+  }
   else
-    {
-      /* they've adked for zero bytes or they've already previously
-       * read everything
-       */
+  {
+    /* they've adked for zero bytes or they've already previously
+     * read everything
+     */
 
-      _IO_SET_READ_NBYTES (ctp, 0);
-      nparts = 0;
-    }
+    _IO_SET_READ_NBYTES(ctp, 0);
+    nparts = 0;
+  }
 
   /* mark the access time as invalid (we just accessed it) */
 
   if (msg->i.nbytes > 0)
     ocb->attr->flags |= IOFUNC_ATTR_ATIME;
 
-  return (_RESMGR_NPARTS (nparts));
-
-
+  return (_RESMGR_NPARTS(nparts));
 }
 
-void
-wait_t (void)
+void wait_t(void)
 {
   struct timeval tv, tv1;
 
-  gettimeofday (&tv1, NULL);
+  gettimeofday(&tv1, NULL);
 
   do
-    {
-      gettimeofday (&tv, NULL);
-    }
-  while (tv.tv_sec - tv1.tv_sec < 3);	// wait for 3 sec.
+  {
+    gettimeofday(&tv, NULL);
+  }
+  while (tv.tv_sec - tv1.tv_sec < 3)
+  {};  // wait for 3 sec.
 
   return;
 }

--- a/hironx_ros_bridge/scripts/hironx.py
+++ b/hironx_ros_bridge/scripts/hironx.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-try: # catkin does not requires load_manifest
+
+try:  # catkin does not requires load_manifest
     import roslib
     import hironx_ros_bridge
 except:
-    import roslib; roslib.load_manifest('hironx_ros_bridge')
+    import roslib
+    import roslib.load_manifest('hironx_ros_bridge')
 
 from hironx_ros_bridge import hironx_client
 
-from hrpsys import rtm  # See https://github.com/tork-a/rtmros_nextage/commit/d4268d81ec14a514bb4b3b52614c81e708dd1ecc#diff-20257dd6ad60c0892cfb122c37a8f2ba 
+# See 'https://github.com/tork-a/rtmros_nextage/commit/' +
+#     'd4268d81ec14a514bb4b3b52614c81e708dd1ecc#' +_
+#     'diff-20257dd6ad60c0892cfb122c37a8f2ba'
+from hrpsys import rtm
 import argparse
 
 if __name__ == '__main__':

--- a/hironx_ros_bridge/scripts/hironx.py
+++ b/hironx_ros_bridge/scripts/hironx.py
@@ -1,13 +1,44 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, JSK Lab, University of Tokyo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided
+# with the distribution.
+# * Neither the name of JSK Lab, University of Tokyo. nor the
+# names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 
 try:  # catkin does not requires load_manifest
-    import roslib
     import hironx_ros_bridge
 except:
     import roslib
-    import roslib.load_manifest('hironx_ros_bridge')
+    roslib.load_manifest('hironx_ros_bridge')
 
 from hironx_ros_bridge import hironx_client
 

--- a/hironx_ros_bridge/src/acceptancetest_hironx.cpp
+++ b/hironx_ros_bridge/src/acceptancetest_hironx.cpp
@@ -197,7 +197,7 @@ public:
     move_armbyarm_jointangles(test_client);
 
     msg_task =
-        "TASK-1. Move each arm separately to the given pose by passing pose in hand space " +
+        "TASK-1. Move each arm separately to the given pose by passing pose in hand space "
         "(i.e. orthogonal coordinate of eef).";
     ROS_INFO("%s", msg_task.c_str());
     msg = msg_type_client + msg_task;
@@ -215,7 +215,7 @@ public:
     wait_input(msg, do_wait_input);
     set_pose_relative(test_client);
 
-    msg_task = "In the beginning you\"ll see the displacement of the previous task." +
+    msg_task = "In the beginning you\"ll see the displacement of the previous task."
         "\nTASK-4. Move head using Joint angles in degree.";
     ROS_INFO("%s", msg_task.c_str());
     msg = msg_type_client + msg_task;
@@ -228,10 +228,10 @@ public:
     wait_input(msg, do_wait_input);
     move_torso(test_client);
 
-    msg_task = std::string("TASK-6. Overwrite ongoing action.\n\t6-1.")
-        + "While rotating torso toward left, it getscanceled and rotate toward"
-        + "right.\n\t6-2. While lifting left hand, right hand also tries to reach"
-            "the same height that gets cancelled so that it stays lower than the left hand.";
+    msg_task = std::string("TASK-6. Overwrite ongoing action.\n\t6-1."
+                           "While rotating torso toward left, it getscanceled and rotate toward "
+                           "right.\n\t6-2. While lifting left hand, right hand also tries to reach "
+			   "the same height that gets cancelled so that it stays lower than the left hand.");
     ROS_INFO("%s", msg_task.c_str());
     msg = msg_type_client + msg_task;
     wait_input(msg, do_wait_input);
@@ -346,9 +346,9 @@ public:
     test_client.set_joint_angles(
         AbstAcceptanceTest::GRNAME_RIGHT_ARM,
         POSITIONS_RARM_DEG_UP_SYNC,
-        std::string("(2) begins. Overwrite previous arm command.\n\t")
-            + "In the beginning both arm starts to move to the\n\tsame height"
-            + "but to the left arm interrupting\ncommand is sent and it goes downward.",
+        std::string("(2) begins. Overwrite previous arm command.\n\t"
+                    "In the beginning both arm starts to move to the\n\tsame height"
+		    "but to the left arm interrupting\ncommand is sent and it goes downward."),
         TASK_DURATION_DEFAULT, false);
 
     ros::Duration(SLEEP_OVERWRITE).sleep();
@@ -356,7 +356,7 @@ public:
     test_client.set_joint_angles(AbstAcceptanceTest::GRNAME_LEFT_ARM, POSITIONS_LARM_DEG_DOWN, "(3)",
                                  TASK_DURATION_DEFAULT, false);
 
-    ros::Duration(<int>TASK_DURATION_DEFAULT).sleep();
+    ros::Duration((int)TASK_DURATION_DEFAULT).sleep();
   }
 
   void show_workspace(AbstAcceptanceTest& test_client)

--- a/hironx_ros_bridge/src/acceptancetest_hironx.cpp
+++ b/hironx_ros_bridge/src/acceptancetest_hironx.cpp
@@ -1,3 +1,37 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2014, TORK (Tokyo Opensource Robotics Kyokai Association)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *  * Neither the name of JSK Lab, University of Tokyo. nor the
+ *    names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include <iostream>
 #include <string>
 #include <vector>
@@ -9,35 +43,37 @@
 
 #include <sstream>
 
-template <class T>
-std::string to_string(T a){
-  std::stringstream ss;
-  ss << a;
-  return ss.str();
-}
+template<class T>
+  std::string to_string(T a)
+  {
+    std::stringstream ss;
+    ss << a;
+    return ss.str();
+  }
 
-class AcceptanceTest_Hiro{
+class AcceptanceTest_Hiro
+{
   /*
-    This class holds methods that can be used for verification of the robot
-    Kawada Industries' dual-arm robot Hiro (and the same model of other robots
-    e.g. NEXTAGE OPEN).
+   This class holds methods that can be used for verification of the robot
+   Kawada Industries' dual-arm robot Hiro (and the same model of other robots
+   e.g. NEXTAGE OPEN).
 
-    This test class is:
-    - Intended to be run as nosetests, ie. roscore isn't available by itself.
-    - Almost all the testcases don't run without an access to a robot running.
+   This test class is:
+   - Intended to be run as nosetests, ie. roscore isn't available by itself.
+   - Almost all the testcases don't run without an access to a robot running.
 
-    Above said, combined with a rostest that launches roscore and robot (either
-    simulation or real) hopefully these testcases can be run, both in batch
-    manner by rostest and in nosetest manner.
+   Above said, combined with a rostest that launches roscore and robot (either
+   simulation or real) hopefully these testcases can be run, both in batch
+   manner by rostest and in nosetest manner.
 
-    Prefix for methods 'at' means 'acceptance test'.
+   Prefix for methods 'at' means 'acceptance test'.
 
-    All time arguments are second.
+   All time arguments are second.
 
-  */
+   */
 public:
   typedef std::vector<double> DVEC;
-  typedef std::vector<DVEC>   DMAT;
+  typedef std::vector<DVEC> DMAT;
 
   static const double positions_larm_deg_up[6];
   static const double positions_larm_deg_down[6];
@@ -59,7 +95,6 @@ public:
   static const double pos_r_x_far_y_far[3];
   static const double rpy_r_x_far_y_far[3];
 
-
   static const double TASK_DURATION_DEFAULT;
   static const double TASK_DURATION_TORSO;
   static const double DURATION_EACH_SMALLINCREMENT;
@@ -67,7 +102,7 @@ public:
   static const int SLEEP_TIME;
   static const int SLEEP_OVERWRITE;
 
-  static const int DURATION_TOTAL_SMALLINCREMENT; // second
+  static const int DURATION_TOTAL_SMALLINCREMENT;  // second
 
   DVEC POSITIONS_LARM_DEG_UP;
   DVEC POSITIONS_LARM_DEG_DOWN;
@@ -89,69 +124,66 @@ public:
   DVEC POS_R_X_FAR_Y_FAR;
   DVEC RPY_R_X_FAR_Y_FAR;
 
-#define INIT_VEC(name,num) name,name+num
-#define VEC_COPY(from,to,N1,N2) for(int i=0;i<N1;++i)for(int j=0;j<N2;++j)to[i][j]=from[i][j];
-  AcceptanceTest_Hiro(std::string name="Hironx(Robot)0",
-		      std::string url="")
-    :rtm_robotname(name),rtm_url(url),
-     ros(ROS_Client()),acceptance_ros_client(ros),
-     POSITIONS_LARM_DEG_UP( INIT_VEC(positions_larm_deg_up,6) ),
-     POSITIONS_LARM_DEG_DOWN( INIT_VEC(positions_larm_deg_down,6) ),
-     POSITIONS_RARM_DEG_DOWN( INIT_VEC(positions_rarm_deg_down,6) ),
-     POSITIONS_LARM_DEG_UP_SYNC( INIT_VEC(positions_larm_deg_up_sync,6) ),
-     POSITIONS_RARM_DEG_UP_SYNC( INIT_VEC(positions_rarm_deg_up_sync,6) ),
+#define INIT_VEC(name, num) name, name+num
+#define VEC_COPY(from, to, N1, N2) for (int i = 0; i < N1; ++i) for (int j = 0; j < N2; ++j)to[i][j] = from[i][j];
+  AcceptanceTest_Hiro(std::string name = "Hironx(Robot)0", std::string url = "") :
+      rtm_robotname(name), rtm_url(url), ros(ROS_Client()), acceptance_ros_client(ros),
+      POSITIONS_LARM_DEG_UP(INIT_VEC(positions_larm_deg_up, 6)),
+      POSITIONS_LARM_DEG_DOWN(INIT_VEC(positions_larm_deg_down, 6)),
+      POSITIONS_RARM_DEG_DOWN(INIT_VEC(positions_rarm_deg_down, 6)),
+      POSITIONS_LARM_DEG_UP_SYNC(INIT_VEC(positions_larm_deg_up_sync, 6)),
+      POSITIONS_RARM_DEG_UP_SYNC(INIT_VEC(positions_rarm_deg_up_sync, 6)),
 
-     ROTATION_ANGLES_HEAD_1(2,DVEC(2)),
-     ROTATION_ANGLES_HEAD_2(2,DVEC(2)),
-     POSITIONS_TORSO_DEG(2,DVEC(1)),
+      ROTATION_ANGLES_HEAD_1(2, DVEC(2)), ROTATION_ANGLES_HEAD_2(2, DVEC(2)), POSITIONS_TORSO_DEG(2, DVEC(1)),
 
-     // WORKSPACE, X NEAR, Y FAR
-     POS_L_X_NEAR_Y_FAR( INIT_VEC(pos_l_x_near_y_far,3) ),
-     RPY_L_X_NEAR_Y_FAR( INIT_VEC(rpy_l_x_near_y_far,3) ),
-     POS_R_X_NEAR_Y_FAR( INIT_VEC(pos_r_x_near_y_far,3) ),
-     RPY_R_X_NEAR_Y_FAR( INIT_VEC(rpy_r_x_near_y_far,3) ),
-     // WORKSPACE, X FAR, Y FAR
-     POS_L_X_FAR_Y_FAR( INIT_VEC(pos_l_x_far_y_far,3) ),
-     RPY_L_X_FAR_Y_FAR( INIT_VEC(rpy_l_x_far_y_far,3) ),
-     POS_R_X_FAR_Y_FAR( INIT_VEC(pos_r_x_far_y_far,3) ),
-     RPY_R_X_FAR_Y_FAR( INIT_VEC(rpy_r_x_far_y_far,3) )
+      // WORKSPACE, X NEAR, Y FAR
+      POS_L_X_NEAR_Y_FAR(INIT_VEC(pos_l_x_near_y_far, 3)), RPY_L_X_NEAR_Y_FAR(INIT_VEC(rpy_l_x_near_y_far, 3)),
+      POS_R_X_NEAR_Y_FAR(INIT_VEC(pos_r_x_near_y_far, 3)), RPY_R_X_NEAR_Y_FAR(INIT_VEC(rpy_r_x_near_y_far, 3)),
+      // WORKSPACE, X FAR, Y FAR
+      POS_L_X_FAR_Y_FAR(INIT_VEC(pos_l_x_far_y_far, 3)), RPY_L_X_FAR_Y_FAR(INIT_VEC(rpy_l_x_far_y_far, 3)),
+      POS_R_X_FAR_Y_FAR(INIT_VEC(pos_r_x_far_y_far, 3)), RPY_R_X_FAR_Y_FAR(INIT_VEC(rpy_r_x_far_y_far, 3))
   {
-    VEC_COPY(rotation_angles_head_1,ROTATION_ANGLES_HEAD_1,2,2)
-      VEC_COPY(rotation_angles_head_2,ROTATION_ANGLES_HEAD_2,2,2)
-      VEC_COPY(positions_torso_deg,POSITIONS_TORSO_DEG,2,1)
-      };
+    VEC_COPY(rotation_angles_head_1, ROTATION_ANGLES_HEAD_1, 2, 2)
+    VEC_COPY(rotation_angles_head_2, ROTATION_ANGLES_HEAD_2, 2, 2)
+    VEC_COPY(positions_torso_deg, POSITIONS_TORSO_DEG, 2, 1)
+  }
 
-  std::string retName(){
+  std::string retName()
+  {
     return rtm_robotname;
   }
 
-  void wait_input(std::string msg, bool do_wait_input = false){
+  void wait_input(std::string msg, bool do_wait_input = false)
+  {
     /*
-      @type msg: str
-      @param msg: To be printed on prompt.
-      @param do_wait_input: If True python commandline waits for any input
-      to proceed.
-    */
-    if(!msg.empty())
+     @type msg: str
+     @param msg: To be printed on prompt.
+     @param do_wait_input: If True python commandline waits for any input
+     to proceed.
+     */
+    if (!msg.empty())
       msg = "\n" + msg + "= ";
-    if(do_wait_input){
+    if (do_wait_input)
+    {
       // exception
     }
   }
 
-  void run_test_ros(bool do_wait_input = false){
+  void run_test_ros(bool do_wait_input = false)
+  {
     /*
-      Run by ROS exactly the same actions that run_tests_rtm performs.
-      @param do_wait_input: If True, the user will be asked to hit any key
-      before each task to proceed.
-    */
+     Run by ROS exactly the same actions that run_tests_rtm performs.
+     @param do_wait_input: If True, the user will be asked to hit any key
+     before each task to proceed.
+     */
     ROS_INFO("********RUN_TEST_ROS************");
-    run_tests(acceptance_ros_client,do_wait_input);
+    run_tests(acceptance_ros_client, do_wait_input);
   }
 
-  void run_tests(AbstAcceptanceTest& test_client,bool do_wait_input = false){
+  void run_tests(AbstAcceptanceTest& test_client, bool do_wait_input = false)
+  {
     std::string msg_type_client = "";
-    if(typeid(test_client) == typeid(AcceptanceTestRos))
+    if (typeid(test_client) == typeid(AcceptanceTestRos))
       msg_type_client = "(ROS) ";
     // else if(typeid(test_client) == typeid(AcceptanceTestRTM))
     //     msg_type_client = "(RTM) ";
@@ -164,14 +196,16 @@ public:
     wait_input(msg, do_wait_input);
     move_armbyarm_jointangles(test_client);
 
-    msg_task = "TASK-1. Move each arm separately to the given pose by passing pose in hand space (i.e. orthogonal coordinate of eef).";
-    ROS_INFO("%s",msg_task.c_str());
+    msg_task =
+        "TASK-1. Move each arm separately to the given pose by passing pose in hand space " +
+        "(i.e. orthogonal coordinate of eef).";
+    ROS_INFO("%s", msg_task.c_str());
     msg = msg_type_client + msg_task;
     wait_input(msg, do_wait_input);
     move_armbyarm_pose(test_client);
 
     msg_task = "TASK-2. Move both arms at the same time using relative distance and angle from the current pose.";
-    ROS_INFO("%s",msg_task.c_str());
+    ROS_INFO("%s", msg_task.c_str());
     msg = msg_type_client + msg_task;
     wait_input(msg, do_wait_input);
     movearms_together(test_client);
@@ -181,27 +215,28 @@ public:
     wait_input(msg, do_wait_input);
     set_pose_relative(test_client);
 
-    msg_task = "In the beginning you\"ll see the displacement of the previous task.\nTASK-4. Move head using Joint angles in degree.";
-    ROS_INFO("%s",msg_task.c_str());
+    msg_task = "In the beginning you\"ll see the displacement of the previous task." +
+        "\nTASK-4. Move head using Joint angles in degree.";
+    ROS_INFO("%s", msg_task.c_str());
     msg = msg_type_client + msg_task;
     wait_input(msg, do_wait_input);
     move_head(test_client);
 
     msg_task = "TASK-5. Rotate torso to the left and right 130 degree.";
-    ROS_INFO("%s",msg_task.c_str());
+    ROS_INFO("%s", msg_task.c_str());
     msg = msg_type_client + msg_task;
     wait_input(msg, do_wait_input);
     move_torso(test_client);
 
-    msg_task = std::string("TASK-6. Overwrite ongoing action.\n\t6-1.") +
-      "While rotating torso toward left, it getscanceled and rotate toward" +
-      "right.\n\t6-2. While lifting left hand, right hand also tries to reach"
-      "the same height that gets cancelled so that it stays lower than the left hand.";
-    ROS_INFO("%s",msg_task.c_str());
+    msg_task = std::string("TASK-6. Overwrite ongoing action.\n\t6-1.")
+        + "While rotating torso toward left, it getscanceled and rotate toward"
+        + "right.\n\t6-2. While lifting left hand, right hand also tries to reach"
+            "the same height that gets cancelled so that it stays lower than the left hand.";
+    ROS_INFO("%s", msg_task.c_str());
     msg = msg_type_client + msg_task;
     wait_input(msg, do_wait_input);
     overwrite_torso(test_client);
-    //task6-2
+    // task6-2
     overwrite_arm(test_client);
 
     msg_task = "TASK-7. Show the capable workspace on front side of the robot.";
@@ -210,156 +245,137 @@ public:
     show_workspace(test_client);
   }
 
-  void move_armbyarm_jointangles(AbstAcceptanceTest& test_client){
+  void move_armbyarm_jointangles(AbstAcceptanceTest& test_client)
+  {
     /*
-      @type test_client: hironx_ros_robotics.abst_acceptancetest.AbstAcceptanceTest
-    */
+     @type test_client: hironx_ros_robotics.abst_acceptancetest.AbstAcceptanceTest
+     */
     test_client.go_initpos(7.0);
     std::string arm = AbstAcceptanceTest::GRNAME_LEFT_ARM;
-    test_client.set_joint_angles(arm, POSITIONS_LARM_DEG_UP,
-				 "Task1 " + to_string(arm));
+    test_client.set_joint_angles(arm, POSITIONS_LARM_DEG_UP, "Task1 " + to_string(arm));
 
     arm = AbstAcceptanceTest::GRNAME_RIGHT_ARM;
-    test_client.set_joint_angles(arm, POSITIONS_RARM_DEG_DOWN,
-				 "Task1 "+to_string(arm));
+    test_client.set_joint_angles(arm, POSITIONS_RARM_DEG_DOWN, "Task1 " + to_string(arm));
     ros::Duration(SLEEP_TIME).sleep();
   }
 
-  void move_armbyarm_pose(AbstAcceptanceTest& test_client){
+  void move_armbyarm_pose(AbstAcceptanceTest& test_client)
+  {
     ROS_INFO("** _move_armbyarm_pose isn\"t yet implemented");
   }
 
-  void movearms_together(AbstAcceptanceTest& test_client){
+  void movearms_together(AbstAcceptanceTest& test_client)
+  {
     // @type test_client: hironx_ros_robotics.abst_acceptancetest.AbstAcceptanceTest
     test_client.go_initpos();
     std::string arm = AbstAcceptanceTest::GRNAME_LEFT_ARM;
-    test_client.set_joint_angles(arm, POSITIONS_LARM_DEG_UP_SYNC,
-				 to_string(arm),
-				 TASK_DURATION_DEFAULT, false);
+    test_client.set_joint_angles(arm, POSITIONS_LARM_DEG_UP_SYNC, to_string(arm), TASK_DURATION_DEFAULT, false);
     /*
-      task2; Under current implementation, left arm
-      always moves first, followed immediately by right arm")
-    */
+     task2; Under current implementation, left arm
+     always moves first, followed immediately by right arm")
+     */
     arm = AbstAcceptanceTest::GRNAME_RIGHT_ARM;
-    test_client.set_joint_angles(arm, POSITIONS_RARM_DEG_DOWN,
-				 to_string(arm),
-				 TASK_DURATION_DEFAULT, false);
+    test_client.set_joint_angles(arm, POSITIONS_RARM_DEG_DOWN, to_string(arm), TASK_DURATION_DEFAULT, false);
     ros::Duration(SLEEP_TIME).sleep();
   }
 
-  void set_pose_relative(AbstAcceptanceTest& test_client){
+  void set_pose_relative(AbstAcceptanceTest& test_client)
+  {
     test_client.go_initpos();
     double delta = R_Z_SMALLINCREMENT;
     double t = DURATION_EACH_SMALLINCREMENT;
     double t_total_sec = DURATION_TOTAL_SMALLINCREMENT;
     int total_increment = t_total_sec / t;
-    std::string msg_1 = "Right arm is moving upward with " + to_string(delta) + "mm increment per "
-      + to_string(t) + "s.";
+    std::string msg_1 = "Right arm is moving upward with " + to_string(delta) + "mm increment per " + to_string(t)
+        + "s.";
     std::string msg_2 = " (Total " + to_string(delta * total_increment) + "cm over " + to_string(t_total_sec) + "s).";
-    ROS_INFO("%s",(msg_1 + msg_2).c_str());
-    for(int i=0;i<total_increment;++i){
+    ROS_INFO("%s", (msg_1 + msg_2).c_str());
+    for (int i = 0; i < total_increment; ++i)
+    {
       std::string msg_eachloop = to_string(i);
       msg_eachloop += "th loop;";
-      test_client.set_pose_relative(AbstAcceptanceTest::GRNAME_RIGHT_ARM,
-                                    0,0,delta,0,0,0,
-                                    msg_eachloop, t, true);
+      test_client.set_pose_relative(AbstAcceptanceTest::GRNAME_RIGHT_ARM, 0, 0, delta, 0, 0, 0, msg_eachloop, t, true);
     }
   }
 
-  void move_head(AbstAcceptanceTest& test_client){
+  void move_head(AbstAcceptanceTest& test_client)
+  {
     test_client.go_initpos();
 
-    for(std::vector< std::vector<double> >::iterator positions = ROTATION_ANGLES_HEAD_1.begin();
-	positions != ROTATION_ANGLES_HEAD_1.end();
-	++positions){
-      test_client.set_joint_angles(AbstAcceptanceTest::GRNAME_HEAD,
-				   *positions,
-				   "(1);",
-				   TASK_DURATION_HEAD);
+    for (std::vector<std::vector<double> >::iterator positions = ROTATION_ANGLES_HEAD_1.begin();
+        positions != ROTATION_ANGLES_HEAD_1.end(); ++positions)
+    {
+      test_client.set_joint_angles(AbstAcceptanceTest::GRNAME_HEAD, *positions, "(1);", TASK_DURATION_HEAD);
     }
-    for(std::vector< std::vector<double> >::iterator positions = ROTATION_ANGLES_HEAD_2.begin();
-	positions != ROTATION_ANGLES_HEAD_2.end();
-	++positions){
-      test_client.set_joint_angles(AbstAcceptanceTest::GRNAME_HEAD,
-				   *positions,
-				   "(2);",
-				   TASK_DURATION_HEAD);
+    for (std::vector<std::vector<double> >::iterator positions = ROTATION_ANGLES_HEAD_2.begin();
+        positions != ROTATION_ANGLES_HEAD_2.end(); ++positions)
+    {
+      test_client.set_joint_angles(AbstAcceptanceTest::GRNAME_HEAD, *positions, "(2);", TASK_DURATION_HEAD);
     }
   }
 
-  void move_torso(AbstAcceptanceTest& test_client){
+  void move_torso(AbstAcceptanceTest& test_client)
+  {
     test_client.go_initpos();
-    for(std::vector< std::vector<double> >::iterator positions = POSITIONS_TORSO_DEG.begin();
-	positions != POSITIONS_TORSO_DEG.end();
-	++positions){
-      test_client.set_joint_angles(AbstAcceptanceTest::GRNAME_TORSO,
-				   *positions);
+    for (std::vector<std::vector<double> >::iterator positions = POSITIONS_TORSO_DEG.begin();
+        positions != POSITIONS_TORSO_DEG.end(); ++positions)
+    {
+      test_client.set_joint_angles(AbstAcceptanceTest::GRNAME_TORSO, *positions);
     }
   }
 
-  void overwrite_torso(AbstAcceptanceTest& test_client){
+  void overwrite_torso(AbstAcceptanceTest& test_client)
+  {
     test_client.go_initpos();
+    test_client.set_joint_angles(AbstAcceptanceTest::GRNAME_TORSO, POSITIONS_TORSO_DEG[0], "(1)", TASK_DURATION_TORSO,
+                                 false);
+
+    ros::Duration(SLEEP_OVERWRITE).sleep();
+
+    test_client.set_joint_angles(AbstAcceptanceTest::GRNAME_TORSO, POSITIONS_TORSO_DEG[1], "(2)", TASK_DURATION_TORSO,
+                                 true);
+
+    ros::Duration(SLEEP_OVERWRITE).sleep();
+  }
+
+  void overwrite_arm(AbstAcceptanceTest& test_client)
+  {
+    test_client.go_initpos();
+    test_client.set_joint_angles(AbstAcceptanceTest::GRNAME_LEFT_ARM, POSITIONS_LARM_DEG_UP_SYNC, "(1)",
+                                 TASK_DURATION_DEFAULT, false);
     test_client.set_joint_angles(
-				 AbstAcceptanceTest::GRNAME_TORSO,
-				 POSITIONS_TORSO_DEG[0],
-				 "(1)",
-				 TASK_DURATION_TORSO,
-				 false);
+        AbstAcceptanceTest::GRNAME_RIGHT_ARM,
+        POSITIONS_RARM_DEG_UP_SYNC,
+        std::string("(2) begins. Overwrite previous arm command.\n\t")
+            + "In the beginning both arm starts to move to the\n\tsame height"
+            + "but to the left arm interrupting\ncommand is sent and it goes downward.",
+        TASK_DURATION_DEFAULT, false);
 
     ros::Duration(SLEEP_OVERWRITE).sleep();
 
-    test_client.set_joint_angles(
-				 AbstAcceptanceTest::GRNAME_TORSO,
-				 POSITIONS_TORSO_DEG[1],
-				 "(2)",
-				 TASK_DURATION_TORSO,
-				 true);
+    test_client.set_joint_angles(AbstAcceptanceTest::GRNAME_LEFT_ARM, POSITIONS_LARM_DEG_DOWN, "(3)",
+                                 TASK_DURATION_DEFAULT, false);
 
-    ros::Duration(SLEEP_OVERWRITE).sleep();
+    ros::Duration(<int>TASK_DURATION_DEFAULT).sleep();
   }
 
-  void overwrite_arm(AbstAcceptanceTest& test_client){
-    test_client.go_initpos();
-    test_client.set_joint_angles(AbstAcceptanceTest::GRNAME_LEFT_ARM, POSITIONS_LARM_DEG_UP_SYNC,
-				 "(1)",
-				 TASK_DURATION_DEFAULT,
-				 false);
-    test_client.set_joint_angles(AbstAcceptanceTest::GRNAME_RIGHT_ARM,
-				 POSITIONS_RARM_DEG_UP_SYNC,
-				 std::string("(2) begins. Overwrite previous arm command.\n\t") +
-                                 "In the beginning both arm starts to move to the\n\tsame height" +
-                                 "but to the left arm interrupting\ncommand is sent and it goes downward.",
-				 TASK_DURATION_DEFAULT,
-				 false);
-
-    ros::Duration(SLEEP_OVERWRITE).sleep();
-
-    test_client.set_joint_angles(AbstAcceptanceTest::GRNAME_LEFT_ARM,
-				 POSITIONS_LARM_DEG_DOWN,
-				 "(3)",
-				 TASK_DURATION_DEFAULT,
-				 false);
-
-    ros::Duration((int)TASK_DURATION_DEFAULT).sleep();
-
-  }
-
-  void show_workspace(AbstAcceptanceTest& test_client){
+  void show_workspace(AbstAcceptanceTest& test_client)
+  {
     test_client.go_initpos();
     std::string msg = "; ";
 
     std::string larm = AbstAcceptanceTest::GRNAME_LEFT_ARM;
     std::string rarm = AbstAcceptanceTest::GRNAME_RIGHT_ARM;
     // X near, Y far.
-    test_client.set_pose(larm, POS_L_X_NEAR_Y_FAR, RPY_L_X_NEAR_Y_FAR,
-                         msg + to_string(larm), TASK_DURATION_DEFAULT, false);
-    test_client.set_pose(rarm, POS_R_X_NEAR_Y_FAR, RPY_R_X_NEAR_Y_FAR,
-                         msg + to_string(rarm), TASK_DURATION_DEFAULT, true);
+    test_client.set_pose(larm, POS_L_X_NEAR_Y_FAR, RPY_L_X_NEAR_Y_FAR, msg + to_string(larm), TASK_DURATION_DEFAULT,
+                         false);
+    test_client.set_pose(rarm, POS_R_X_NEAR_Y_FAR, RPY_R_X_NEAR_Y_FAR, msg + to_string(rarm), TASK_DURATION_DEFAULT,
+                         true);
     // X far, Y far.
-    test_client.set_pose(larm, POS_L_X_FAR_Y_FAR, RPY_L_X_FAR_Y_FAR,
-                         msg + to_string(larm), TASK_DURATION_DEFAULT, false);
-    test_client.set_pose(rarm, POS_R_X_FAR_Y_FAR, RPY_R_X_FAR_Y_FAR,
-                         msg + to_string(rarm), TASK_DURATION_DEFAULT, true);
+    test_client.set_pose(larm, POS_L_X_FAR_Y_FAR, RPY_L_X_FAR_Y_FAR, msg + to_string(larm), TASK_DURATION_DEFAULT,
+                         false);
+    test_client.set_pose(rarm, POS_R_X_FAR_Y_FAR, RPY_R_X_FAR_Y_FAR, msg + to_string(rarm), TASK_DURATION_DEFAULT,
+                         true);
   }
 
 private:
@@ -368,30 +384,29 @@ private:
 
   ROS_Client ros;
   AcceptanceTestRos acceptance_ros_client;
-
 };
 
 // init parameters
 const double AcceptanceTest_Hiro::positions_larm_deg_up[6] = {-4.697, -2.012, -117.108, -17.180, 29.146, -3.739};
 const double AcceptanceTest_Hiro::positions_larm_deg_down[6] = {6.196, -5.311, -73.086, -15.287, -12.906, -2.957};
 const double AcceptanceTest_Hiro::positions_rarm_deg_down[6] = {-4.949, -3.372, -80.050, 15.067, -7.734, 3.086};
-const double AcceptanceTest_Hiro::positions_larm_deg_up_sync[6] =  {-4.695, -2.009, -117.103, -17.178, 29.138, -3.738};
-const double AcceptanceTest_Hiro::positions_rarm_deg_up_sync[6] =  {4.695, -2.009, -117.103, 17.178, 29.138, 3.738};
-const double AcceptanceTest_Hiro::rotation_angles_head_1[2][2] = {{0.1, 0.0}, {50.0, 10.0}};
+const double AcceptanceTest_Hiro::positions_larm_deg_up_sync[6] = {-4.695, -2.009, -117.103, -17.178, 29.138, -3.738};
+const double AcceptanceTest_Hiro::positions_rarm_deg_up_sync[6] = {4.695, -2.009, -117.103, 17.178, 29.138, 3.738};
+const double AcceptanceTest_Hiro::rotation_angles_head_1[2][2] = { {0.1, 0.0}, {50.0, 10.0}};
 const double AcceptanceTest_Hiro::rotation_angles_head_2[2][2] = { {-50, -10}, {0, 0}};
-const double AcceptanceTest_Hiro::positions_torso_deg[2][1] =  {{130.0}, {-130.0}};
+const double AcceptanceTest_Hiro::positions_torso_deg[2][1] = { {130.0}, {-130.0}};
 
-const double AcceptanceTest_Hiro::R_Z_SMALLINCREMENT =  0.0001;
+const double AcceptanceTest_Hiro::R_Z_SMALLINCREMENT = 0.0001;
 // Workspace; X near, Y far
-const double AcceptanceTest_Hiro::pos_l_x_near_y_far[3] =  {0.326, 0.474, 1.038};
+const double AcceptanceTest_Hiro::pos_l_x_near_y_far[3] = {0.326, 0.474, 1.038};
 const double AcceptanceTest_Hiro::rpy_l_x_near_y_far[3] = {-3.075, -1.569, 3.074};
 const double AcceptanceTest_Hiro::pos_r_x_near_y_far[3] = {0.326, -0.472, 1.048};
 const double AcceptanceTest_Hiro::rpy_r_x_near_y_far[3] = {3.073, -1.569, -3.072};
 // workspace; x far, y far
-const double AcceptanceTest_Hiro::pos_l_x_far_y_far[3] =  {0.47548142379781055, 0.17430276793604782, 1.0376878025614884};
-const double AcceptanceTest_Hiro::rpy_l_x_far_y_far[3] =  {-3.075954857224205, -1.5690261926181046, 3.0757659493049574};
-const double AcceptanceTest_Hiro::pos_r_x_far_y_far[3] =  {0.4755337947019357, -0.17242322190721648, 1.0476395479774052};
-const double AcceptanceTest_Hiro::rpy_r_x_far_y_far[3] =  {3.0715850722714944, -1.5690204449882248, -3.071395243174742};
+const double AcceptanceTest_Hiro::pos_l_x_far_y_far[3] = {0.47548142379781055, 0.17430276793604782, 1.0376878025614884};
+const double AcceptanceTest_Hiro::rpy_l_x_far_y_far[3] = {-3.075954857224205, -1.5690261926181046, 3.0757659493049574};
+const double AcceptanceTest_Hiro::pos_r_x_far_y_far[3] = {0.4755337947019357, -0.17242322190721648, 1.0476395479774052};
+const double AcceptanceTest_Hiro::rpy_r_x_far_y_far[3] = {3.0715850722714944, -1.5690204449882248, -3.071395243174742};
 
 const double AcceptanceTest_Hiro::TASK_DURATION_DEFAULT = 4.0;
 const double AcceptanceTest_Hiro::DURATION_EACH_SMALLINCREMENT = 0.1;
@@ -401,9 +416,10 @@ const int AcceptanceTest_Hiro::SLEEP_TIME = 2;
 const int AcceptanceTest_Hiro::SLEEP_OVERWRITE = 2;
 
 const int AcceptanceTest_Hiro::DURATION_TOTAL_SMALLINCREMENT = 30;  // Second.
-int main(int argc,char* argv[]){
+int main(int argc, char* argv[])
+{
   // Init the ROS node
-  ros::init(argc,argv,"hironx_ros_client");
+  ros::init(argc, argv, "hironx_ros_client");
 
   AcceptanceTest_Hiro test;
   test.run_test_ros();

--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
@@ -37,7 +37,8 @@ import numpy
 import os
 import time
 
-import roslib; roslib.load_manifest("hrpsys")
+import roslib
+roslib.load_manifest("hrpsys")
 from hrpsys.hrpsys_config import *
 import OpenHRP
 import OpenRTM_aist
@@ -55,14 +56,15 @@ _MSG_ASK_ISSUEREPORT = 'Your report to ' + \
 
 class HIRONX(HrpsysConfigurator):
     '''
-    @see: <a href = "https://github.com/fkanehiro/hrpsys-base/blob/master/python/hrpsys_config.py">HrpsysConfigurator</a>
+    @see: <a href = "https://github.com/fkanehiro/hrpsys-base/blob/master/" +
+                    "python/hrpsys_config.py">HrpsysConfigurator</a>
 
     This class holds methods that are specific to Kawada Industries' dual-arm
     robot called Hiro.
 
-    For the API doc for the derived methods, please see the parent 
+    For the API doc for the derived methods, please see the parent
     class via the link above; nicely formatted api doc web page
-    isn't available yet (discussed in 
+    isn't available yet (discussed in
     https://github.com/fkanehiro/hrpsys-base/issues/268).
     '''
 
@@ -76,25 +78,26 @@ class HIRONX(HrpsysConfigurator):
     '''
     For OffPose and _InitialPose, the angles of each joint are listed in the
     ordered as defined in Groups variable.'''
-    OffPose = [[0], [0, 0],
-                   [25, -139, -157, 45, 0, 0],
-                   [-25, -139, -157, -45, 0, 0],
-                   [0, 0, 0, 0],
-                   [0, 0, 0, 0]]
+    OffPose = [[0],
+               [0, 0],
+               [25, -139, -157, 45, 0, 0],
+               [-25, -139, -157, -45, 0, 0],
+               [0, 0, 0, 0],
+               [0, 0, 0, 0]]
     # With this pose the EEFs level up the tabletop surface.
     _InitialPose = [[0], [0, 0],
-                   [-0.6, 0, -100, 15.2, 9.4, 3.2],
-                   [0.6, 0, -100, -15.2, 9.4, -3.2],
-                   [0, 0, 0, 0],
-                   [0, 0, 0, 0]]
+                    [-0.6, 0, -100, 15.2, 9.4, 3.2],
+                    [0.6, 0, -100, -15.2, 9.4, -3.2],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0]]
     # This pose sets joint angles at the factory initial pose. No danger, but
     # no real advange either for in normal usage.
     # See https://github.com/start-jsk/rtmros_hironx/issues/107
     _InitialPose_Factory = [[0], [0, 0],
-                   [-0, 0, -130, 0, 0, 0],
-                   [0, 0, -130, 0, 0, 0],
-                   [0, 0, 0, 0],
-                   [0, 0, 0, 0]]
+                            [-0, 0, -130, 0, 0, 0],
+                            [0, 0, -130, 0, 0, 0],
+                            [0, 0, 0, 0],
+                            [0, 0, 0, 0]]
     INITPOS_TYPE_EVEN = 0
     INITPOS_TYPE_FACTORY = 1
 
@@ -157,9 +160,10 @@ class HIRONX(HrpsysConfigurator):
         ret = True
         for i in range(len(self.Groups)):
             # radangles = [x/180.0*math.pi for x in self._InitialPose[i]]
-            print self.configurator_name, 'self.setJointAnglesOfGroup(', \
-                  self.Groups[i][0], ',', _INITPOSE[i], ', ', tm, \
-                  ',wait=False)'
+            print(
+                '{}, JntAnglesOfGr={}, INITPOSE[i]={}, tm={}, wait={}'.format(
+                    self.configurator_name, self.Groups[i][0], _INITPOSE[i],
+                    tm, wait))
             ret &= self.setJointAnglesOfGroup(self.Groups[i][0],
                                               _INITPOSE[i],
                                               tm, wait=False)
@@ -199,7 +203,7 @@ class HIRONX(HrpsysConfigurator):
         hardcoded value (100mm), by internally calling self.setHandWidth.
 
         @type hand: str
-        @param hand: Name of the hand joint group. In the default 
+        @param hand: Name of the hand joint group. In the default
                      setting of HIRONX, hand joint groups are defined
                      in member 'HandGroups' where 'lhand' and 'rhand'
                      are added.
@@ -209,11 +213,11 @@ class HIRONX(HrpsysConfigurator):
 
     def HandClose(self, hand=None, effort=None):
         '''
-        Close 2-finger hand, by internally calling self.setHandWidth 
+        Close 2-finger hand, by internally calling self.setHandWidth
         setting 0 width.
 
         @type hand: str
-        @param hand: Name of the hand joint group. In the default 
+        @param hand: Name of the hand joint group. In the default
                      setting of HIRONX, hand joint groups are defined
                      in member 'HandGroups' where 'lhand' and 'rhand'
                      are added.
@@ -224,7 +228,7 @@ class HIRONX(HrpsysConfigurator):
     def setHandJointAngles(self, hand, angles, tm=1):
         '''
         @type hand: str
-        @param hand: Name of the hand joint group. In the default 
+        @param hand: Name of the hand joint group. In the default
                      setting of HIRONX, hand joint groups are defined
                      in member 'HandGroups' where 'lhand' and 'rhand'
                      are added.
@@ -246,7 +250,7 @@ class HIRONX(HrpsysConfigurator):
     def setHandWidth(self, hand, width, tm=1, effort=None):
         '''
         @type hand: str
-        @param hand: Name of the hand joint group. In the default 
+        @param hand: Name of the hand joint group. In the default
                      setting of HIRONX, hand joint groups are defined
                      in member 'HandGroups' where 'lhand' and 'rhand'
                      are added.
@@ -319,7 +323,10 @@ class HIRONX(HrpsysConfigurator):
         '''
         Returns the physical state of robot.
 
-        @rtype: <a href = "http://hrpsys-base.googlecode.com/svn/doc/df/d17/structOpenHRP_1_1RobotHardwareService_1_1RobotState.html">OpenHRP::RobotHardwareService::RobotState</a>
+        @rtype: <a href = "http://hrpsys-base.googlecode.com/svn/doc/df/d17/" +
+                          "structOpenHRP_1_1RobotHardwareService_1_1" +
+                          "RobotState.html">
+                          OpenHRP::RobotHardwareService::RobotState</a>
         @return: Robot's hardware status object that contains the following
                  variables accessible: angle, command, torque, servoState,
                  force, rateGyro, accel, voltage, current. See the api doc
@@ -432,7 +439,7 @@ class HIRONX(HrpsysConfigurator):
         #self.rh_svc.power('all', SWITCH_ON)  #do not switch on before goActual
 
         try:
-            waitInputConfirm(\
+            waitInputConfirm(
                 '!! Robot Motion Warning (SERVO_ON) !!\n\n'
                 'Confirm RELAY switched ON\n'
                 'Push [OK] to switch servo ON(%s).' % (jname))

--- a/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py
@@ -94,11 +94,11 @@ class ROS_Client(object):
 
     def _init_action_clients(self):
         self._aclient_larm = actionlib.SimpleActionClient(
-             '/larm_controller/joint_trajectory_action', JointTrajectoryAction)
+            '/larm_controller/joint_trajectory_action', JointTrajectoryAction)
         self._aclient_rarm = actionlib.SimpleActionClient(
-             '/rarm_controller/joint_trajectory_action', JointTrajectoryAction)
+            '/rarm_controller/joint_trajectory_action', JointTrajectoryAction)
         self._aclient_head = actionlib.SimpleActionClient(
-             '/head_controller/joint_trajectory_action', JointTrajectoryAction)
+            '/head_controller/joint_trajectory_action', JointTrajectoryAction)
         self._aclient_torso = actionlib.SimpleActionClient(
             '/torso_controller/joint_trajectory_action', JointTrajectoryAction)
 
@@ -134,10 +134,10 @@ class ROS_Client(object):
 
         rospy.loginfo('Joint names; ' +
                       'Torso: {}\n\tHead: {}\n\tL-Arm: {}\n\tR-Arm: {}'.format(
-                                    self._goal_torso.trajectory.joint_names,
-                                    self._goal_head.trajectory.joint_names,
-                                    self._goal_larm.trajectory.joint_names,
-                                    self._goal_rarm.trajectory.joint_names))
+                          self._goal_torso.trajectory.joint_names,
+                          self._goal_head.trajectory.joint_names,
+                          self._goal_larm.trajectory.joint_names,
+                          self._goal_rarm.trajectory.joint_names))
 
     def _set_groupnames(self, groupnames):
         '''
@@ -197,7 +197,7 @@ class ROS_Client(object):
             action_client = self._aclient_rarm
             goal = self._goal_rarm
         else:
-            #TODO: Throw exception; a valid group name isn't passed.
+            # TODO: Throw exception; a valid group name isn't passed.
             rospy.logerr('groupname {} not assigned'.format(groupname))
 
         try:
@@ -206,12 +206,13 @@ class ROS_Client(object):
             pt.time_from_start = rospy.Duration(duration)
             goal.trajectory.points = [pt]
             goal.trajectory.header.stamp = \
-                             rospy.Time.now() + rospy.Duration(duration)
+                rospy.Time.now() + rospy.Duration(duration)
 
             action_client.send_goal(goal)
             if wait:
-                rospy.loginfo('wait_for_result for the joint group {} = {}'.format(
-                                   groupname, action_client.wait_for_result()))
+                rospy.loginfo(
+                    'wait_for_result for the joint group {} = {}'.format(
+                        groupname, action_client.wait_for_result()))
         except rospy.ROSInterruptException as e:
             rospy.loginfo(e.str())
 
@@ -253,7 +254,9 @@ class ROS_Client(object):
         @type rpy: [float]
         @param rpy: If None, keep the current orientation by using
                     MoveGroupCommander.set_position_target. See:
-                    http://moveit.ros.org/doxygen/classmoveit__commander_1_1move__group_1_1MoveGroupCommander.html#acfe2220fd85eeb0a971c51353e437753
+                     'http://moveit.ros.org/doxygen/' +
+                     'classmoveit__commander_1_1move__group_1_1' +
+                     'MoveGroupCommander.html#acfe2220fd85eeb0a971c51353e437753'
         @param ref_frame_name: TODO: Not utilized yet. Need to be implemented.
         '''
         # Check if MoveGroup is instantiated.
@@ -266,13 +269,10 @@ class ROS_Client(object):
 
         # Locally assign the specified MoveGroup
         movegr = None
-        rospy.loginfo('Constant.GRNAME_LEFT_ARM={}'.format(Constant.GRNAME_LEFT_ARM))
         if Constant.GRNAME_LEFT_ARM == joint_group:
-            rospy.loginfo('222')
             movegr = self._movegr_larm
         elif Constant.GRNAME_RIGHT_ARM == joint_group:
             movegr = self._movegr_rarm
-            rospy.loginfo('333')
         else:
             rospy.loginfo('444')
 
@@ -286,11 +286,10 @@ class ROS_Client(object):
 
         # Not necessary to convert from rpy to quaternion, since
         # MoveGroupCommander.set_pose_target can take rpy format too.
-        # orientation_quaternion = quaternion_from_euler(rpy[0], rpy[1], rpy[2])
         pose = copy.deepcopy(position)
         pose.extend(rpy)
-        rospy.loginfo('ROS set_pose joint_group={} movegroup={} pose={} position={} rpy={}'.format(
-                                     joint_group, movegr, pose, position, rpy))
+        rospy.loginfo('setpose jntgr={} mvgr={} pose={} posi={} rpy={}'.format(
+                      joint_group, movegr, pose, position, rpy))
         try:
             movegr.set_pose_target(pose)
         except MoveItCommanderException as e:
@@ -298,5 +297,5 @@ class ROS_Client(object):
         except Exception as e:
             rospy.logerr(str(e))
 
-        movegr.go(do_wait) or movegr.go(do_wait) or rospy.logerr(
-                          'MoveGroup.go fails; jointgr={}'.format(joint_group))
+        (movegr.go(do_wait) or movegr.go(do_wait) or
+         rospy.logerr('MoveGroup.go fails; jointgr={}'.format(joint_group)))


### PR DESCRIPTION
Note:
- Most of the changes in the codes were made by using [Eclipse code formatter](http://wiki.ros.org/IDEs#Auto_Formatting) for both C++ and Python. But there were so many `lint` errors as well that weren't captured so that had to be manually modified.
- For Python files, only those that users would use are `lint`ed, mainly because there are so many files I can't handle.
