### PR TITLE
(hironx_ros_bridge) Trying to remove dependency on pr2 components.

### DIFF
--- a/hironx_ros_bridge/catkin.cmake
+++ b/hironx_ros_bridge/catkin.cmake
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(hironx_ros_bridge)
 
-find_package(catkin REQUIRED COMPONENTS hrpsys_ros_bridge pr2_controllers_msgs roslib roslint rostest)
+find_package(catkin REQUIRED COMPONENTS control_msgs hrpsys_ros_bridge roslib roslint rostest)
 find_package(Boost REQUIRED COMPONENTS system)
 
 catkin_package(
     CATKIN_DEPENDS std_msgs
-    CATKIN_DEPENDS hrpsys_ros_bridge pr2_controllers_msgs roslib #
+    CATKIN_DEPENDS control_msgs hrpsys_ros_bridge roslib #
     INCLUDE_DIRS include
     LIBRARIES ros_client_cpp
 )

--- a/hironx_ros_bridge/include/ros_client.cpp
+++ b/hironx_ros_bridge/include/ros_client.cpp
@@ -36,9 +36,9 @@
 #define ROS_CLIENT_HPP
 
 #include <ros/ros.h>
-#include <pr2_controllers_msgs/JointTrajectoryAction.h>
-#include <pr2_controllers_msgs/JointTrajectoryActionGoal.h>
-#include <pr2_controllers_msgs/JointTrajectoryGoal.h>
+#include <control_msgs/FollowJointTrajectoryAction.h>
+#include <control_msgs/JointTrajectoryActionGoal.h>
+#include <control_msgs/JointTrajectoryGoal.h>
 #include <trajectory_msgs/JointTrajectoryPoint.h>
 #include <actionlib/client/simple_action_client.h>
 #include <string>
@@ -62,9 +62,9 @@ class ROS_Client
   // or somewhere in the upstream, e.g.:
   // https://github.com/fkanehiro/hrpsys-base/pull/253
 public:
-  typedef actionlib::SimpleActionClient<pr2_controllers_msgs::JointTrajectoryAction> TrajClient;
+  typedef actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction> TrajClient;
 
-  pr2_controllers_msgs::JointTrajectoryGoal goal;
+  control_msgs::JointTrajectoryGoal goal;
 
   ROS_Client() :
       GR_TORSO("torso"), GR_HEAD("head"), GR_LARM("larm"), GR_RARM("rarm"), MSG_ASK_ISSUEREPORT(
@@ -111,7 +111,7 @@ public:
 
     aclient_larm.waitForServer();
     ROS_INFO("ros_client; 1");
-    goal_larm = pr2_controllers_msgs::JointTrajectoryGoal();
+    goal_larm = control_msgs::JointTrajectoryGoal();
     ROS_INFO("ros_client; 2");
     goal_larm.trajectory.joint_names.push_back("LARM_JOINT0");
     goal_larm.trajectory.joint_names.push_back("LARM_JOINT1");
@@ -122,7 +122,7 @@ public:
     ROS_INFO("ros_client; 3");
 
     aclient_rarm.waitForServer();
-    goal_rarm = pr2_controllers_msgs::JointTrajectoryGoal();
+    goal_rarm = control_msgs::JointTrajectoryGoal();
     goal_rarm.trajectory.joint_names.push_back("RARM_JOINT0");
     goal_rarm.trajectory.joint_names.push_back("RARM_JOINT1");
     goal_rarm.trajectory.joint_names.push_back("RARM_JOINT2");
@@ -131,12 +131,12 @@ public:
     goal_rarm.trajectory.joint_names.push_back("RARM_JOINT5");
 
     aclient_head.waitForServer();
-    goal_head = pr2_controllers_msgs::JointTrajectoryGoal();
+    goal_head = control_msgs::JointTrajectoryGoal();
     goal_head.trajectory.joint_names.push_back("HEAD_JOINT0");
     goal_head.trajectory.joint_names.push_back("HEAD_JOINT1");
 
     aclient_torso.waitForServer();
-    goal_torso = pr2_controllers_msgs::JointTrajectoryGoal();
+    goal_torso = control_msgs::JointTrajectoryGoal();
     goal_torso.trajectory.joint_names.push_back("CHEST_JOINT0");
 
     // Display Joint names
@@ -262,10 +262,10 @@ private:
 
   const std::string MSG_ASK_ISSUEREPORT;
 
-  pr2_controllers_msgs::JointTrajectoryGoal goal_larm;
-  pr2_controllers_msgs::JointTrajectoryGoal goal_rarm;
-  pr2_controllers_msgs::JointTrajectoryGoal goal_head;
-  pr2_controllers_msgs::JointTrajectoryGoal goal_torso;
+  control_msgs::JointTrajectoryGoal goal_larm;
+  control_msgs::JointTrajectoryGoal goal_rarm;
+  control_msgs::JointTrajectoryGoal goal_head;
+  control_msgs::JointTrajectoryGoal goal_torso;
 
   /*
    param groupnames: List of the joint group names. Assumes to be in the

--- a/hironx_ros_bridge/package.xml
+++ b/hironx_ros_bridge/package.xml
@@ -14,9 +14,9 @@
   <url type="bugtracker">https://github.com/start-jsk/rtmros_hironx/issues</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>control_msgs</build_depend>
   <build_depend>hrpsys_ros_bridge</build_depend> <!-- Needed to transitively depend on openhrp3. See https://github.com/start-jsk/rtmros_hironx/pull/30#commitcomment-5535604 -->
   <build_depend>mk</build_depend>
-  <build_depend>pr2_controllers_msgs</build_depend>
   <build_depend>roslib</build_depend>
   <build_depend>roslint</build_depend>
   <build_depend>rosbash</build_depend>
@@ -25,10 +25,10 @@
   <build_depend>unzip</build_depend>
   <build_depend>gnuplot</build_depend>
 
+  <run_depend>control_msgs</run_depend>
   <run_depend>gnuplot</run_depend>
   <run_depend>moveit_commander</run_depend>
   <run_depend>hrpsys_ros_bridge</run_depend>
-  <run_depend>pr2_controllers_msgs</run_depend>
   <run_depend>roslib</run_depend>
   <run_depend>rosbash</run_depend>
   <run_depend>rospy</run_depend>

--- a/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py
@@ -36,11 +36,11 @@ import copy
 import math
 
 import actionlib
+from control_msgs.msg import FollowJointTrajectoryAction
+from control_msgs.msg import JointTrajectoryGoal
 from moveit_commander import MoveGroupCommander
 from moveit_commander import MoveItCommanderException
 import rospy
-from pr2_controllers_msgs.msg import JointTrajectoryAction
-from pr2_controllers_msgs.msg import JointTrajectoryGoal
 from trajectory_msgs.msg import JointTrajectoryPoint
 from tf.transformations import quaternion_from_euler
 
@@ -94,13 +94,13 @@ class ROS_Client(object):
 
     def _init_action_clients(self):
         self._aclient_larm = actionlib.SimpleActionClient(
-            '/larm_controller/joint_trajectory_action', JointTrajectoryAction)
+            '/larm_controller/joint_trajectory_action', FollowJointTrajectoryAction)
         self._aclient_rarm = actionlib.SimpleActionClient(
-            '/rarm_controller/joint_trajectory_action', JointTrajectoryAction)
+            '/rarm_controller/joint_trajectory_action', FollowJointTrajectoryAction)
         self._aclient_head = actionlib.SimpleActionClient(
-            '/head_controller/joint_trajectory_action', JointTrajectoryAction)
+            '/head_controller/joint_trajectory_action', FollowJointTrajectoryAction)
         self._aclient_torso = actionlib.SimpleActionClient(
-            '/torso_controller/joint_trajectory_action', JointTrajectoryAction)
+            '/torso_controller/joint_trajectory_action', FollowJointTrajectoryAction)
 
         self._aclient_larm.wait_for_server()
         rospy.loginfo('ros_client; 1')

--- a/hironx_ros_bridge/test/test_hironx_ros_bridge.py
+++ b/hironx_ros_bridge/test/test_hironx_ros_bridge.py
@@ -17,12 +17,11 @@ from tf.transformations import quaternion_matrix, euler_from_matrix
 import unittest
 
 # for catkin compiled environment, pr2_controller_msgs is not catkinized
-roslib.load_manifest('pr2_controllers_msgs')
-import pr2_controllers_msgs.msg
+import control_msgs.msg
 import trajectory_msgs.msg
 
 from sensor_msgs.msg import JointState
-from pr2_controllers_msgs.msg import JointTrajectoryAction
+from control_msgs.msg import FollowJointTrajectory
 from trajectory_msgs.msg import JointTrajectoryPoint
 from hrpsys_ros_bridge.srv import *
 
@@ -90,7 +89,7 @@ class TestHiroROSBridge(unittest.TestCase):
         self.torso.wait_for_result()
 
     def goal_LArm(self):
-        goal = pr2_controllers_msgs.msg.JointTrajectoryGoal()
+        goal = control_msgs.msg.JointTrajectoryGoal()
         goal.trajectory.joint_names.append("LARM_JOINT0")
         goal.trajectory.joint_names.append("LARM_JOINT1")
         goal.trajectory.joint_names.append("LARM_JOINT2")
@@ -100,7 +99,7 @@ class TestHiroROSBridge(unittest.TestCase):
         return goal
 
     def goal_RArm(self):
-        goal = pr2_controllers_msgs.msg.JointTrajectoryGoal()
+        goal = control_msgs.msg.JointTrajectoryGoal()
         goal.trajectory.joint_names.append("RARM_JOINT0")
         goal.trajectory.joint_names.append("RARM_JOINT1")
         goal.trajectory.joint_names.append("RARM_JOINT2")
@@ -110,12 +109,12 @@ class TestHiroROSBridge(unittest.TestCase):
         return goal
 
     def goal_Torso(self):
-        goal = pr2_controllers_msgs.msg.JointTrajectoryGoal()
+        goal = control_msgs.msg.JointTrajectoryGoal()
         goal.trajectory.joint_names.append("CHEST_JOINT0")
         return goal
 
     def goal_Head(self):
-        goal = pr2_controllers_msgs.msg.JointTrajectoryGoal()
+        goal = control_msgs.msg.JointTrajectoryGoal()
         goal.trajectory.joint_names.append("HEAD_JOINT0")
         goal.trajectory.joint_names.append("HEAD_JOINT1")
         return goal


### PR DESCRIPTION
DO NOT MERGE YET. 

Trying to replace `pr2_controllers_msgs` with `control_msgs`, which is available even on Groovy.
However this PReq didin't work out of the box -- In order to remove the dependency on `pr2_controllers_msgs`, we first need to do so in the upstream, i.e. `hrpsys_ros_bridge`.

```
$ rtmlaunch hironx_ros_bridge hironx_ros_bridge_simulation.launch
:
[ERROR] [1412177051.938004616, 163.504999999]: Client [/hrpsys_py] wants topic /torso_controller/joint_trajectory_action/feedback to have datatype/md5sum [control_msgs/FollowJointTrajectoryActionFeedback/d8920dc4eae9fc107e00999cce4be641], but our version has [pr2_controllers_msgs/JointTrajectoryActionFeedback/aae20e09065c3809e8a8e87c4c8953fd]. Dropping connection.
[ERROR] [1412177051.942261574, 163.509999999]: Client [/hironx_ros_client] wants topic /torso_controller/joint_trajectory_action/feedback to have datatype/md5sum [control_msgs/FollowJointTrajectoryActionFeedback/d8920dc4eae9fc107e00999cce4be641], but our version has [pr2_controllers_msgs/JointTrajectoryActionFeedback/aae20e09065c3809e8a8e87c4c8953fd]. Dropping connection.
[ERROR] [1412177051.965842171, 163.524999999]: Client [/hironx_ros_client] wants topic /torso_controller/joint_trajectory_action/result to have datatype/md5sum [control_msgs/FollowJointTrajectoryActionResult/bce83d50f7bb28226801436caf0e2043], but our version has [pr2_controllers_msgs/JointTrajectoryActionResult/1eb06eeff08fa7ea874431638cb52332]. Dropping connection.
[ERROR] [1412177051.966107624, 163.524999999]: Client [/hrpsys_py] wants topic /torso_controller/joint_trajectory_action/result to have datatype/md5sum [control_msgs/FollowJointTrajectoryActionResult/bce83d50f7bb28226801436caf0e2043], but our version has [pr2_controllers_msgs/JointTrajectoryActionResult/1eb06eeff08fa7ea874431638cb52332]. Dropping connection.
```

```
$ ipython -i `rospack find hironx_ros_bridge`/scripts/acceptancetest_hironx.py
:
[WARN] [WallTime: 1412177019.515932] [133.715000] Could not process inbound connection: topic types do not match: [pr2_controllers_msgs/JointTrajectoryActionGoal] vs. [control_msgs/FollowJointTrajectoryActionGoal]{'topic': '/larm_controller/joint_trajectory_action/goal', 'tcp_nodelay': '0', 'md5sum': 'a99e83ef6185f9fdd7693efe99623a86', 'type': 'pr2_controllers_msgs/JointTrajectoryActionGoal', 'callerid': '/HrpsysJointTrajectoryBridge'}
[WARN] [WallTime: 1412177019.633108] [133.860000] Could not process inbound connection: topic types do not match: [pr2_controllers_msgs/JointTrajectoryActionGoal] vs. [control_msgs/FollowJointTrajectoryActionGoal]{'topic': '/rarm_controller/joint_trajectory_action/goal', 'tcp_nodelay': '0', 'md5sum': 'a99e83ef6185f9fdd7693efe99623a86', 'type': 'pr2_controllers_msgs/JointTrajectoryActionGoal', 'callerid': '/HrpsysJointTrajectoryBridge'}
```

Also, `ros_client.cpp` doesn't build with this.

```
$ catkin_make
:
/home/rosmacaroni/cws_hiro_nxo/src/start-jsk/rtmros_hironx/hironx_ros_bridge/include/ros_client.cpp:232:35: error: no matching function for call to ‘actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction_<std::allocator<void> > >::sendGoal(control_msgs::JointTrajectoryGoal&)’
/home/rosmacaroni/cws_hiro_nxo/src/start-jsk/rtmros_hironx/hironx_ros_bridge/include/ros_client.cpp:232:35: note: candidate is:
/opt/ros/hydro/include/actionlib/client/simple_action_client.h:313:6: note: void actionlib::SimpleActionClient<ActionSpec>::sendGoal(const Goal&, actionlib::SimpleActionClient<ActionSpec>::SimpleDoneCallback, actionlib::SimpleActionClient<ActionSpec>::SimpleActiveCallback, actionlib::SimpleActionClient<ActionSpec>::SimpleFeedbackCallback) [with ActionSpec = control_msgs::FollowJointTrajectoryAction_<std::allocator<void> >, actionlib::SimpleActionClient<ActionSpec>::Goal = control_msgs::FollowJointTrajectoryGoal_<std::allocator<void> >, actionlib::SimpleActionClient<ActionSpec>::SimpleDoneCallback = boost::function<void(const actionlib::SimpleClientGoalState&, const boost::shared_ptr<const control_msgs::FollowJointTrajectoryResult_<std::allocator<void> > >&)>, typename ActionSpec::_action_result_type::_result_type = control_msgs::FollowJointTrajectoryResult_<std::allocator<void> >, actionlib::SimpleActionClient<ActionSpec>::SimpleActiveCallback = boost::function<void()>, actionlib::SimpleActionClient<ActionSpec>::SimpleFeedbackCallback = boost::function<void(const boost::shared_ptr<const control_msgs::FollowJointTrajectoryFeedback_<std::allocator<void> > >&)>, typename ActionSpec::_action_feedback_type::_feedback_type = control_msgs::FollowJointTrajectoryFeedback_<std::allocator<void> >]
/opt/ros/hydro/include/actionlib/client/simple_action_client.h:313:6: note:   no known conversion for argument 1 from ‘control_msgs::JointTrajectoryGoal’ to ‘const Goal& {aka const control_msgs::FollowJointTrajectoryGoal_<std::allocator<void> >&}’
make[2]: *** [start-jsk/rtmros_hironx/hironx_ros_bridge/CMakeFiles/ros_client_cpp.dir/include/ros_client.cpp.o] Error 1
make[1]: *** [start-jsk/rtmros_hironx/hironx_ros_bridge/CMakeFiles/ros_client_cpp.dir/all] Error 2
make: *** [all] Error 2
Invoking "make" failed
```
