### PR TITLE
(hironx_ros_bridge) add missing run_depend package.

### DIFF
--- a/hironx_ros_bridge/package.xml
+++ b/hironx_ros_bridge/package.xml
@@ -28,6 +28,7 @@
   <run_depend>gnuplot</run_depend>
   <run_depend>moveit_commander</run_depend>
   <run_depend>hrpsys_ros_bridge</run_depend>
+  <run_depend>openni2_launch</run_depend>
   <run_depend>pr2_controllers_msgs</run_depend>
   <run_depend>roslib</run_depend>
   <run_depend>rosbash</run_depend>


### PR DESCRIPTION
`openni2_launch` is [needed in a launch file](https://github.com/start-jsk/rtmros_hironx/blob/6e3b52aa92bb163751e4f07b3c281c84019fa993/hironx_ros_bridge/launch/hironx_kinect.launch#L10).
