### PR TITLE
Add launch files with simpler names.

### DIFF
--- a/hironx_ros_bridge/launch/ros_real.launch
+++ b/hironx_ros_bridge/launch/ros_real.launch
@@ -1,0 +1,3 @@
+<launch>
+  <include file="$(find hironx_ros_bridge)/launch/hironx_ros_bridge_real.launch" />
+</launch>

--- a/hironx_ros_bridge/launch/ros_sim.launch
+++ b/hironx_ros_bridge/launch/ros_sim.launch
@@ -1,0 +1,3 @@
+<launch>
+  <include file="$(find hironx_ros_bridge)/launch/hironx_ros_bridge_simulation.launch" />
+</launch>


### PR DESCRIPTION
After observing a few seminars and workshops, I noticed that many people don't take advantage of tab-completion nor command history, and instead type in long commands, which tends to result in typos and even worse causing reluctance. Launch is one of the things most commonly run at those occasions.
