### PR TITLE
(Robot installer) accept hrpsys version via argument

### DIFF
--- a/hironx_ros_bridge/robot/robot-compile-freeze.sh
+++ b/hironx_ros_bridge/robot/robot-compile-freeze.sh
@@ -15,8 +15,33 @@
 ##
 # set -x
 
+HRPSYS_VERSION_DEFAULT=315.2.8
+
+function usage {
+    echo >&2 "usage: $0 [version_hrpsys (default:$HRPSYS_VERSION_DEFAULT)]
+    echo >&2 "          [-h|--help] print this message"
+    exit 0
+}
+
 trap 'exit 1', ERR
 
+# command line parse
+OPT=`getopt -o h -l help -- $*`
+if [ $? != 0 ]; then
+    usage
+fi
+
+eval set -- $OPT
+
+while [ -n "$1" ] ; do
+    case $1 in
+        -h|--help) usage ;;
+        --) shift; break;;
+        *) echo "Unknown option($1)"; usage;;
+    esac
+done
+
+HRPSYS_VERSION=${3-"$HRPSYS_VERSION_DEFAULT"}
 ## Path of freeze.py on QNX.jenkins.jsk. This should better be taken from argument in the future. 
 FREEZE=/home/sam/hiro-nxo_sys-check/freeze_bin/usr/share/doc/python2.7/examples/Tools/freeze/freeze.py
 TMPDIR=`mktemp -d`
@@ -27,7 +52,7 @@ cd $TMPDIR
 ## Create a "opt_jsk_hex.h" file that encapsulates the streamlined /opt/jsk tarball 
 python <<EOF
 import binascii
-f_exe = open("/tmp/opt_jsk_315.1.10.tgz", 'r');
+f_exe = open("/tmp/opt_jsk_$HRPSYS_VERSION.tgz", 'r');
 f_txt = open('opt_jsk_hex.h', 'w')
 f_txt.write('std::string bin_data="')
 f_txt.write(binascii.hexlify(f_exe.read()))

--- a/hironx_ros_bridge/robot/robot-compile-freeze.sh
+++ b/hironx_ros_bridge/robot/robot-compile-freeze.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 
 ##
+## robot-compile-freeze.sh creates an ELF32 binary. It's named as `robot-install-qnx-%MAC_ADDR_QNX%`
+## that runs on QNX to install hrpsys (and its other required libraries). 
+## The binary doesn't specify the path where the binary files get installed 
+## (that is up to users' manual operation in the later process).
+## Currently it's assumed to run only on QNX.jenkins.jsk (paths are hardcoded). 
+##
 ## ssh to target QNX
 ## $ tar -cvzf /tmp/opt_jsk_<hrpsys_version>.tgz /opt/jsk_<hrspys_version>
 ## run this script 
@@ -11,16 +17,18 @@
 
 trap 'exit 1', ERR
 
+## Path of freeze.py on QNX.jenkins.jsk. This should better be taken from argument in the future. 
 FREEZE=/home/sam/hiro-nxo_sys-check/freeze_bin/usr/share/doc/python2.7/examples/Tools/freeze/freeze.py
 TMPDIR=`mktemp -d`
 OUTDIR=`pwd`
 
 cd $TMPDIR
 
+## Create a "opt_jsk_hex.h" file that encapsulates the streamlined /opt/jsk tarball 
 python <<EOF
 import binascii
 f_exe = open("/tmp/opt_jsk_315.1.10.tgz", 'r');
-f_txt = open('opt_jsk_hex.h','w')
+f_txt = open('opt_jsk_hex.h', 'w')
 f_txt.write('std::string bin_data="')
 f_txt.write(binascii.hexlify(f_exe.read()))
 f_txt.write('";')
@@ -28,11 +36,13 @@ f_exe.close()
 f_txt.close()
 EOF
 
+## Read MAC address, generate md5 checksum for it.
 echo -n "input password = (MAC address) "
 read PASS
 CHECK=`python -c "import hashlib; m=hashlib.md5(); m.update(\"$PASS\"); print m.hexdigest()"`;
 echo "check sum ... $CHECK"
 
+## Write the following text between 2 EOFs into robot-install.cpp
 cat <<EOF > robot-install.cpp
 
 #include <string>
@@ -84,6 +94,7 @@ int main () {
     struct sockaddr_dl *sdl = NULL;
     char iface[] = "wm0";
 
+    // TODO: What's this check for? 
     if (getifaddrs(&ifaphead) != 0) {
       perror("get_if_name: getifaddrs() failed");
       exit(1);
@@ -92,7 +103,7 @@ int main () {
     for (ifap = ifaphead; ifap && !found; ifap = ifap->ifa_next) {
       if ((ifap->ifa_addr->sa_family == AF_LINK)) {
         if (strlen(ifap->ifa_name) == strlen(iface))
-          if (strcmp(ifap->ifa_name,iface) == 0) {
+          if (strcmp(ifap->ifa_name, iface) == 0) {
             found = 1;
             sdl = (struct sockaddr_dl *)ifap->ifa_addr;
             if (sdl) {
@@ -105,7 +116,7 @@ int main () {
       }
     }
     if (!found) {
-      fprintf (stderr,"Can't find interface %s.\n",iface);
+      fprintf (stderr, "Can't find interface %s.\n", iface);
       if(ifaphead)
           freeifaddrs(ifaphead);
       exit(1);
@@ -117,6 +128,7 @@ int main () {
    if(ifaphead)
      freeifaddrs(ifaphead);
 
+    // TODO: Indentation is ambiguous from here.
     cerr << "mac = " << buffer << endl;
 
     // md5sum
@@ -126,6 +138,7 @@ int main () {
     for(i =0; i < MD5_DIGEST_LENGTH; i++ )
       sprintf(&buffer[i*2], "%02x", result[i]);
     cerr << "md5sum = " << buffer << endl;
+    // TODO: Comparing something with MAC address, and return error if not match??? 
     if (string(buffer) != string("$CHECK") ) {
        cerr << "invalid password" << endl;       
        remove_all(tmpdir);
@@ -136,7 +149,7 @@ int main () {
     string filename = string(tmpdir) + "/out.tgz";
     ofstream fout(filename.c_str(), ios::app);
     for (string::size_type i=0; i<bin_data.length(); i+=2) {
-        unsigned char b = (unsigned char) strtoul(bin_data.substr(i,2).c_str(), NULL, 16);
+        unsigned char b = (unsigned char) strtoul(bin_data.substr(i, 2).c_str(), NULL, 16);
         fout << b;
     }
     fout.close();
@@ -159,5 +172,3 @@ qcc -o robot-install -I/usr/pkg/include robot-install.cpp -L/usr/pkg/lib -lboost
 cp robot-install ${OUTDIR}/robot-install-${PASS}
 
 rm -fr $TMPDIR
-
-

--- a/hironx_ros_bridge/robot/robot-compile-setup.sh
+++ b/hironx_ros_bridge/robot/robot-compile-setup.sh
@@ -31,26 +31,32 @@ hrpsys_version=${hrpsys_version:="315.2.8"}
 
 DATE=`date +%Y-%m-%d`
 
+# Detect if the target robot is Hiro or NX.
+#ssh $userid@$hostname ls /opt/hiro && export IS_TARGET_HIRO=true
+
 TMPDIR=/tmp/HiroNXO_install
 URL_HIRONX_ZIPBALL=https://github.com/start-jsk/rtmros_hironx/archive/1.0.27.zip
 URL_NXO_ZIPBALL_STABLE=https://github.com/tork-a/rtmros_nextage/archive/0.2.14.zip
 mkdir -p ${TMPDIR}/opt/jsk/${hrpsys_version}
 # Download model files.
-wget ${URL_HIRONX_ZIPBALL} -O ${TMPDIR}/rtmros_hironx.zip || echo "ERROR:: Failed to download hironx zipball."
+##wget ${URL_HIRONX_ZIPBALL} -O ${TMPDIR}/rtmros_hironx.zip || echo "ERROR:: Failed to download hironx zipball."
+##(cd ${TMPDIR}; unzip -o rtmros_hironx.zip)
 wget ${URL_NXO_ZIPBALL_STABLE} -O ${TMPDIR}/rtmros_nextage.zip || echo "ERROR:: Failed to download nxo zipball."
+(cd ${TMPDIR}; unzip -o rtmros_nextage.zip)
 # Download 'base' libraries for QNX that don't be affected by the hrpsys version
 wget 'https://docs.google.com/uc?authuser=0&id=0B5hXrFUpyR2iZS0tQlFyXzhjaGc&export=download' -O ${TMPDIR}/opt-jsk-base.tgz || echo "ERROR:: Failed to download opt-jsk-base.tgz."
 
 (cd ${TMPDIR}; tar -xvzf opt-jsk-base.tgz)
-(cd ${TMPDIR}; unzip -o rtmros_hironx.zip)
-(cd ${TMPDIR}; unzip -o rtmros_nextage.zip)
 # The tarball above (opt-jsk-base.tgz) contains `include` and `lib` folders, only. So from here we'll create other folders.
 mkdir -p ${TMPDIR}/opt/jsk/${hrpsys_version}/etc
-mv ${TMPDIR}/*/hironx_ros_bridge/ ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/HIRONX
+##mv ${TMPDIR}/*/hironx_ros_bridge/ ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/HIRONX
 # zipball retrieved by URL_NXO_ZIPBALL_STABLE yields random folder name. So skip it by asterisk.
 mv ${TMPDIR}/*/nextage_description/ ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/NEXTAGE
+# VRML model file of Hiro is not opensourced yet. It should be found in /opt/jsk/etc/HIRONX in each robot.
+#mv ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/HIRONX/models ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/HIRONX/model
+ssh $userid@$hostname ls /opt/hiro && (export IS_TARGET_HIRO="true"; ssh $userid@$hostname "tar cfvz /tmp/hiro_wrl.tgz /opt/jsk/etc/HIRONX;"; scp $userid@$hostname:/tmp/hiro_wrl.tgz /tmp/hiro_wrl.tgz; cd ${TMPDIR} && tar xfvz /tmp/hiro_wrl.tgz ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/; ls ${TMPDIR}) || echo "The robot you're dealing with now is NEXTAGE."
+##HIRO_COPY_MODEL="echo 'It is Hiro, so use existing model files.'; cp -R /opt/jsk/$HRPSYS_PREV_INSTALLED/etc/HIRONX /opt/jsk/$hrpsys_version/etc;" || echo "The robot you're dealing with now is NEXTAGE."
 # Folder names from nextage_description and the one used internal to QNX is different. See https://github.com/start-jsk/rtmros_hironx/issues/160#issuecomment-48572336
-mv ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/HIRONX/models ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/HIRONX/model
 mv ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/NEXTAGE/models ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/NEXTAGE/model
 tar -C ${TMPDIR} -cvzf ${TMPDIR}/opt-jsk-base-model.tgz ./opt/jsk/${hrpsys_version}/
 
@@ -69,13 +75,13 @@ commands="
   echo \"* If /opt/jsk is a symlink, remove it (it'll be generated later within this script. *\";
   echo \"* Else if /opt/jsk is a directory, not a symlink, it's a folder containing OSS controller libraries. *\";
   echo \"* So move it aside with hrpsys version and the timestamp as a part of dir name (eg. /opt/jsk/315.2.0_20141214). *\";
-  test -L /opt/jsk && su -c 'rm -fr /opt/jsk' || (su -c 'mkdir /opt/jsk/$HRPSYS_PREV_INSTALLED' && su -c 'mv /opt/jsk/* /opt/jsk/$HRPSYS_PREV_INSTALLED');
+  test -L /opt/jsk && su -c 'rm -fr /opt/jsk' || (mkdir /tmp/$HRPSYS_PREV_INSTALLED && su -c 'mv /opt/jsk/* /tmp/$HRPSYS_PREV_INSTALLED'; echo 'ls /opt/jsk' && ls /opt/jsk && su -c 'mv /tmp/$HRPSYS_PREV_INSTALLED /opt/jsk');
   echo \"* setup /opt/jsk/$hrpsys_version directory *\";
   cd /;
   su -c 'tar -xvzf /tmp/opt-jsk-base-model.tgz';
   echo \"* Create supplemental folder '/opt/jsk/$hrpsys_version/var/log' *\";
   su -c 'mkdir -p /opt/jsk/$hrpsys_version/var/log';
-  echo \"* Symbolic link from folders in /opt/jsk to the ones that contain specific hrpsys version. *\";
+  echo \"* Symbolic link from folders in /opt/jsk to the ones that contain specific hrpsys version. Sym-linking didn't work from the directory. *\";
   cd /opt/jsk;
   su -c 'ln -sf /opt/jsk/$hrpsys_version/* .';
   "

--- a/hironx_ros_bridge/robot/robot-compile-setup.sh
+++ b/hironx_ros_bridge/robot/robot-compile-setup.sh
@@ -34,7 +34,7 @@ DATE=`date +%Y-%m-%d`
 TMPDIR=/tmp/HiroNXO_install
 URL_HIRONX_ZIPBALL=https://github.com/start-jsk/rtmros_hironx/archive/1.0.27.zip
 URL_NXO_ZIPBALL_STABLE=https://github.com/tork-a/rtmros_nextage/archive/0.2.14.zip
-mkdir -p ${TMPDIR}/opt/jsk_${hrpsys_version}
+mkdir -p ${TMPDIR}/opt/jsk/${hrpsys_version}
 # Download model files.
 wget ${URL_HIRONX_ZIPBALL} -O ${TMPDIR}/rtmros_hironx.zip || echo "ERROR:: Failed to download hironx zipball."
 wget ${URL_NXO_ZIPBALL_STABLE} -O ${TMPDIR}/rtmros_nextage.zip || echo "ERROR:: Failed to download nxo zipball."
@@ -45,14 +45,14 @@ wget 'https://docs.google.com/uc?authuser=0&id=0B5hXrFUpyR2iZS0tQlFyXzhjaGc&expo
 (cd ${TMPDIR}; unzip -o rtmros_hironx.zip)
 (cd ${TMPDIR}; unzip -o rtmros_nextage.zip)
 # The tarball above (opt-jsk-base.tgz) contains `include` and `lib` folders, only. So from here we'll create other folders.
-mkdir -p ${TMPDIR}/opt/jsk_${hrpsys_version}/etc
-mv ${TMPDIR}/*/hironx_ros_bridge/ ${TMPDIR}/opt/jsk_${hrpsys_version}/etc/HIRONX
+mkdir -p ${TMPDIR}/opt/jsk/${hrpsys_version}/etc
+mv ${TMPDIR}/*/hironx_ros_bridge/ ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/HIRONX
 # zipball retrieved by URL_NXO_ZIPBALL_STABLE yields random folder name. So skip it by asterisk.
-mv ${TMPDIR}/*/nextage_description/ ${TMPDIR}/opt/jsk_${hrpsys_version}/etc/NEXTAGE
+mv ${TMPDIR}/*/nextage_description/ ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/NEXTAGE
 # Folder names from nextage_description and the one used internal to QNX is different. See https://github.com/start-jsk/rtmros_hironx/issues/160#issuecomment-48572336
-mv ${TMPDIR}/opt/jsk_${hrpsys_version}/etc/HIRONX/models ${TMPDIR}/opt/jsk_${hrpsys_version}/etc/HIRONX/model
-mv ${TMPDIR}/opt/jsk_${hrpsys_version}/etc/NEXTAGE/models ${TMPDIR}/opt/jsk_${hrpsys_version}/etc/NEXTAGE/model
-tar -C ${TMPDIR} -cvzf ${TMPDIR}/opt-jsk-base-model.tgz ./opt/jsk_${hrpsys_version}/
+mv ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/HIRONX/models ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/HIRONX/model
+mv ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/NEXTAGE/models ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/NEXTAGE/model
+tar -C ${TMPDIR} -cvzf ${TMPDIR}/opt-jsk-base-model.tgz ./opt/jsk/${hrpsys_version}/
 
 # Command that gets run on QNX. 
 # Assumption: NO /opt/jsk directory exists on QNX.
@@ -65,14 +65,15 @@ commands="
   echo \"* If /opt/jsk is a symlink, remove it (it'll be generated later within this script. *\";
   echo \"* Else if /opt/jsk is a directory, not a symlink, it's a folder containing OSS controller libraries. *\";
   echo \"* So move it aside with hrpsys version and the timestamp as a part of dir name (eg. /opt/jsk_315.2.0_20141214). *\";
-  test -L /opt/jsk && su -c 'rm -fr /opt/jsk' || su -c 'mv /opt/jsk /opt/jsk_$(strings RobotHardware.so | grep ^[0-9]*\\.[0-9]*\\.[0-9]*$)_$(date +%Y%m%d)'
-  echo \"* setup /opt/jsk_$hrpsys_version directory *\";
+  test -L /opt/jsk && su -c 'rm -fr /opt/jsk' || su -c 'mv /opt/jsk /opt/jsk/$(strings RobotHardware.so | grep ^[0-9]*\\.[0-9]*\\.[0-9]*$)_$(date +%Y%m%d)'
+  echo \"* setup /opt/jsk/$hrpsys_version directory *\";
   cd /;
   su -c 'tar -xvzf /tmp/opt-jsk-base-model.tgz';
-  echo \"* Create supplemental folder '/opt/jsk_$hrpsys_version/var/log' *\";
-  su -c 'mkdir -p /opt/jsk_$hrpsys_version/var/log';
-  echo \"* Symbolic link from /opt/jsk to the one that contains specific hrpsys version. *\";
-  su -c 'ln -sf /opt/jsk_$hrpsys_version /opt/jsk';
+  echo \"* Create supplemental folder '/opt/jsk/$hrpsys_version/var/log' *\";
+  su -c 'mkdir -p /opt/jsk/$hrpsys_version/var/log';
+  echo \"* Symbolic link from folders in /opt/jsk to the ones that contain specific hrpsys version. *\";
+  cd /opt/jsk
+  su -c 'ln -sf /opt/jsk/$hrpsys_version/* .';
   "
 
 echo "Necessary files are prepared on your host and now ready to run these commands inside the robot = $commands"

--- a/hironx_ros_bridge/robot/robot-compile-setup.sh
+++ b/hironx_ros_bridge/robot/robot-compile-setup.sh
@@ -54,6 +54,10 @@ mv ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/HIRONX/models ${TMPDIR}/opt/jsk/${hrp
 mv ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/NEXTAGE/models ${TMPDIR}/opt/jsk/${hrpsys_version}/etc/NEXTAGE/model
 tar -C ${TMPDIR} -cvzf ${TMPDIR}/opt-jsk-base-model.tgz ./opt/jsk/${hrpsys_version}/
 
+# Get the version of hrpsys that is working inside of QNX.
+scp $userid@$hostname:/opt/jsk/lib/RobotHardware.so /tmp
+HRPSYS_PREV_INSTALLED=$(strings /tmp/RobotHardware.so  | grep ^[0-9]*\\.[0-9]*\\.[0-9]*$)
+
 # Command that gets run on QNX. 
 # Assumption: NO /opt/jsk directory exists on QNX.
 # Writing into new directory that's created by root requires root privilege.
@@ -64,8 +68,8 @@ commands="
   set +x;
   echo \"* If /opt/jsk is a symlink, remove it (it'll be generated later within this script. *\";
   echo \"* Else if /opt/jsk is a directory, not a symlink, it's a folder containing OSS controller libraries. *\";
-  echo \"* So move it aside with hrpsys version and the timestamp as a part of dir name (eg. /opt/jsk_315.2.0_20141214). *\";
-  test -L /opt/jsk && su -c 'rm -fr /opt/jsk' || su -c 'mv /opt/jsk /opt/jsk/lib/$(strings RobotHardware.so | grep ^[0-9]*\\.[0-9]*\\.[0-9]*$)_$(date +%Y%m%d)'
+  echo \"* So move it aside with hrpsys version and the timestamp as a part of dir name (eg. /opt/jsk/315.2.0_20141214). *\";
+  test -L /opt/jsk && su -c 'rm -fr /opt/jsk' || (su -c 'mkdir /opt/jsk/$HRPSYS_PREV_INSTALLED' && su -c 'mv /opt/jsk/* /opt/jsk/$HRPSYS_PREV_INSTALLED');
   echo \"* setup /opt/jsk/$hrpsys_version directory *\";
   cd /;
   su -c 'tar -xvzf /tmp/opt-jsk-base-model.tgz';

--- a/hironx_ros_bridge/robot/robot-compile-setup.sh
+++ b/hironx_ros_bridge/robot/robot-compile-setup.sh
@@ -72,7 +72,7 @@ commands="
   echo \"* Create supplemental folder '/opt/jsk/$hrpsys_version/var/log' *\";
   su -c 'mkdir -p /opt/jsk/$hrpsys_version/var/log';
   echo \"* Symbolic link from folders in /opt/jsk to the ones that contain specific hrpsys version. *\";
-  cd /opt/jsk
+  cd /opt/jsk;
   su -c 'ln -sf /opt/jsk/$hrpsys_version/* .';
   "
 

--- a/hironx_ros_bridge/robot/robot-compile-setup.sh
+++ b/hironx_ros_bridge/robot/robot-compile-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function usage {
-    echo >&2 "usage: $0 [hostname (default:hiro014)] [username (default:hiro)]"
+    echo >&2 "usage: $0 [hostname (default:hiro014)] [username (default:hiro)] [hrpsys_version (default:315.2.8)]"
     echo >&2 "          [-h|--help] print this message"
     exit 0
 }
@@ -26,32 +26,42 @@ hostname=$1
 hostname=${hostname:="hiro014"} 
 userid=$2
 userid=${userid:="hiro"} 
+hrpsys_version=$3
+hrpsys_version=${hrpsys_version:="315.2.8"} 
 
 DATE=`date +%Y-%m-%d`
 
 TMPDIR=/tmp/HOGE
 URL_NXO_LATEST_ZIPBALL=https://github.com/tork-a/rtmros_nextage/archive/0.2.14.zip
-mkdir -p ${TMPDIR}/opt/jsk
+mkdir -p ${TMPDIR}/opt/jsk_${hrpsys_version}
+# Download NEXTAGE model files.
 wget ${URL_NXO_LATEST_ZIPBALL} -O ${TMPDIR}/rtmros_nextage.zip || echo "ERROR:: Failed to download source code"
+# Download 'base' libraries for QNX that don't be affected by the hrpsys version  
 wget 'https://docs.google.com/uc?authuser=0&id=0B5hXrFUpyR2iZS0tQlFyXzhjaGc&export=download' -O ${TMPDIR}/opt-jsk-base.tgz || echo "ERROR:: Failed to download source code"
 
 (cd ${TMPDIR}; tar -xvzf opt-jsk-base.tgz)
 (cd ${TMPDIR}; unzip -o rtmros_nextage.zip)
-mkdir -p ${TMPDIR}/opt/jsk/etc
+mkdir -p ${TMPDIR}/opt/jsk_${hrpsys_version}/etc
 # zipball retrieved by URL_NXO_LATEST_ZIPBALL yields random folder name. So skip it by asterisk.
-mv ${TMPDIR}/*/nextage_description/ ${TMPDIR}/opt/jsk/etc/HIRONX 
-mv ${TMPDIR}/opt/jsk/etc/HIRONX/models ${TMPDIR}/opt/jsk/etc/HIRONX/model
-tar -C ${TMPDIR} -cvzf ${TMPDIR}/opt-jsk-base-model.tgz ./opt/jsk/
+mv ${TMPDIR}/*/nextage_description/ ${TMPDIR}/opt/jsk_${hrpsys_version}/etc/HIRONX 
+mv ${TMPDIR}/opt/jsk_${hrpsys_version}/etc/HIRONX/models ${TMPDIR}/opt/jsk_${hrpsys_version}/etc/HIRONX/model
+tar -C ${TMPDIR} -cvzf ${TMPDIR}/opt-jsk-base-model.tgz ./opt/jsk_${hrpsys_version}/
 
+# Command that gets run on QNX. 
+# Assumption: NO /opt/jsk directory exists on QNX.
+# Writing into new directory that's created by root requires root privilege.
 commands="
   . ~/.profile;
   env;
   trap 'exit 1' ERR;
   set +x;
-  echo \"* setup /opt/jsk directory *\";
+  echo \"* setup /opt/jsk_$hrpsys_version directory *\";
   cd /;
-  tar -xvzf /tmp/opt-jsk-base-model.tgz;
-  mkdir -p /opt/jsk/var/log
+  su -c 'tar -xvzf /tmp/opt-jsk-base-model.tgz';
+  echo \"* Create supplemental folder '/opt/jsk_$hrpsys_version/var/log' *\";
+  su -c 'mkdir -p /opt/jsk_$hrpsys_version/var/log';
+  echo \"* Symbolic link from /opt/jsk to the one that contains specific hrpsys version. *\";
+  su -c 'ln -sf /opt/jsk_$hrpsys_version /opt/jsk';
   "
 
 echo "Necessary files are prepared on your host and now ready to run these commands inside the robot = $commands"

--- a/hironx_ros_bridge/robot/robot-compile-setup.sh
+++ b/hironx_ros_bridge/robot/robot-compile-setup.sh
@@ -65,7 +65,7 @@ commands="
   echo \"* If /opt/jsk is a symlink, remove it (it'll be generated later within this script. *\";
   echo \"* Else if /opt/jsk is a directory, not a symlink, it's a folder containing OSS controller libraries. *\";
   echo \"* So move it aside with hrpsys version and the timestamp as a part of dir name (eg. /opt/jsk_315.2.0_20141214). *\";
-  test -L /opt/jsk && su -c 'rm -fr /opt/jsk' || su -c 'mv /opt/jsk /opt/jsk/$(strings RobotHardware.so | grep ^[0-9]*\\.[0-9]*\\.[0-9]*$)_$(date +%Y%m%d)'
+  test -L /opt/jsk && su -c 'rm -fr /opt/jsk' || su -c 'mv /opt/jsk /opt/jsk/lib/$(strings RobotHardware.so | grep ^[0-9]*\\.[0-9]*\\.[0-9]*$)_$(date +%Y%m%d)'
   echo \"* setup /opt/jsk/$hrpsys_version directory *\";
   cd /;
   su -c 'tar -xvzf /tmp/opt-jsk-base-model.tgz';

--- a/hironx_ros_bridge/robot/robot-compile-setup.sh
+++ b/hironx_ros_bridge/robot/robot-compile-setup.sh
@@ -31,20 +31,27 @@ hrpsys_version=${hrpsys_version:="315.2.8"}
 
 DATE=`date +%Y-%m-%d`
 
-TMPDIR=/tmp/HOGE
-URL_NXO_LATEST_ZIPBALL=https://github.com/tork-a/rtmros_nextage/archive/0.2.14.zip
+TMPDIR=/tmp/HiroNXO_install
+URL_HIRONX_ZIPBALL=https://github.com/start-jsk/rtmros_hironx/archive/1.0.27.zip
+URL_NXO_ZIPBALL_STABLE=https://github.com/tork-a/rtmros_nextage/archive/0.2.14.zip
 mkdir -p ${TMPDIR}/opt/jsk_${hrpsys_version}
-# Download NEXTAGE model files.
-wget ${URL_NXO_LATEST_ZIPBALL} -O ${TMPDIR}/rtmros_nextage.zip || echo "ERROR:: Failed to download source code"
-# Download 'base' libraries for QNX that don't be affected by the hrpsys version  
-wget 'https://docs.google.com/uc?authuser=0&id=0B5hXrFUpyR2iZS0tQlFyXzhjaGc&export=download' -O ${TMPDIR}/opt-jsk-base.tgz || echo "ERROR:: Failed to download source code"
+# Download model files.
+wget ${URL_HIRONX_ZIPBALL} -O ${TMPDIR}/rtmros_hironx.zip || echo "ERROR:: Failed to download hironx zipball."
+wget ${URL_NXO_ZIPBALL_STABLE} -O ${TMPDIR}/rtmros_nextage.zip || echo "ERROR:: Failed to download nxo zipball."
+# Download 'base' libraries for QNX that don't be affected by the hrpsys version
+wget 'https://docs.google.com/uc?authuser=0&id=0B5hXrFUpyR2iZS0tQlFyXzhjaGc&export=download' -O ${TMPDIR}/opt-jsk-base.tgz || echo "ERROR:: Failed to download opt-jsk-base.tgz."
 
 (cd ${TMPDIR}; tar -xvzf opt-jsk-base.tgz)
+(cd ${TMPDIR}; unzip -o rtmros_hironx.zip)
 (cd ${TMPDIR}; unzip -o rtmros_nextage.zip)
+# The tarball above (opt-jsk-base.tgz) contains `include` and `lib` folders, only. So from here we'll create other folders.
 mkdir -p ${TMPDIR}/opt/jsk_${hrpsys_version}/etc
-# zipball retrieved by URL_NXO_LATEST_ZIPBALL yields random folder name. So skip it by asterisk.
-mv ${TMPDIR}/*/nextage_description/ ${TMPDIR}/opt/jsk_${hrpsys_version}/etc/HIRONX 
+mv ${TMPDIR}/*/hironx_ros_bridge/ ${TMPDIR}/opt/jsk_${hrpsys_version}/etc/HIRONX
+# zipball retrieved by URL_NXO_ZIPBALL_STABLE yields random folder name. So skip it by asterisk.
+mv ${TMPDIR}/*/nextage_description/ ${TMPDIR}/opt/jsk_${hrpsys_version}/etc/NEXTAGE
+# Folder names from nextage_description and the one used internal to QNX is different. See https://github.com/start-jsk/rtmros_hironx/issues/160#issuecomment-48572336
 mv ${TMPDIR}/opt/jsk_${hrpsys_version}/etc/HIRONX/models ${TMPDIR}/opt/jsk_${hrpsys_version}/etc/HIRONX/model
+mv ${TMPDIR}/opt/jsk_${hrpsys_version}/etc/NEXTAGE/models ${TMPDIR}/opt/jsk_${hrpsys_version}/etc/NEXTAGE/model
 tar -C ${TMPDIR} -cvzf ${TMPDIR}/opt-jsk-base-model.tgz ./opt/jsk_${hrpsys_version}/
 
 # Command that gets run on QNX. 

--- a/hironx_ros_bridge/robot/robot-compile-setup.sh
+++ b/hironx_ros_bridge/robot/robot-compile-setup.sh
@@ -55,6 +55,10 @@ commands="
   env;
   trap 'exit 1' ERR;
   set +x;
+  echo \"* If /opt/jsk is a symlink, remove it (it'll be generated later within this script. *\";
+  echo \"* Else if /opt/jsk is a directory, not a symlink, it's a folder containing OSS controller libraries. *\";
+  echo \"* So move it aside with hrpsys version and the timestamp as a part of dir name (eg. /opt/jsk_315.2.0_20141214). *\";
+  test -L /opt/jsk && su -c 'rm -fr /opt/jsk' || su -c 'mv /opt/jsk /opt/jsk_$(strings RobotHardware.so | grep ^[0-9]*\\.[0-9]*\\.[0-9]*$)_$(date +%Y%m%d)'
   echo \"* setup /opt/jsk_$hrpsys_version directory *\";
   cd /;
   su -c 'tar -xvzf /tmp/opt-jsk-base-model.tgz';

--- a/hironx_ros_bridge/robot/robot-create-user.sh
+++ b/hironx_ros_bridge/robot/robot-create-user.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+function usage {
+    echo >&2 "usage: $0 [hostname (default:hiro014)] [rootuser_qnx (default:hiro)]"
+    echo >&2 "          [-h|--help] Print help message."
+    exit 0
+}
+
+# command line parse. If the num of argument is not as expected, call usage func.
+OPT=`getopt -o h -l help -- $*`
+if [ $# != 2 ]; then
+    usage
+fi
+
+eval set -- $OPT
+
+while [ -n "$1" ] ; do
+    case $1 in
+        -h|--help) usage ;;
+        --) shift; break;;
+        *) echo "Unknown option($1)"; usage;;
+    esac
+done
+
+hostname=$1
+hostname=${hostname:="hiro014"} 
+rootuser_qnx=$2
+rootuser_qnx=${rootuser_qnx:="hiro"}
+NEW_USER_QNX='tork'
+NEW_USER_QNX_CAPITAL='TORK'
+OSS_FOLDER='/opt/jsk'
+
+# Command that gets run on QNX. 
+# - Create tork user,
+# - Assign write access for tork user to /opt/jsk folder recursively.
+commands="
+  . ~/.profile;
+  env;
+  trap 'exit 1' ERR;
+  set +x;
+  echo \"* If tork user already exists, exit. *\";
+  echo \"* Else, create tork user, the one that can write into the folder where OSS gets installed. *\";
+  test -e /home/$NEW_USER_QNX && (echo \"** Looks like the user '$NEW_USER_QNX' already exists. Installer exits. **\" && exit 0) || (echo \"** Looks like the user '$NEW_USER_QNX' does not exist. So let's create the user.\n   Keep using default values by pressing enter key, except for:\n\t(1) user name='$NEW_USER_QNX_CAPITAL'\n\t(2) password='$NEW_USER_QNX'.\n**\" && su -c 'passwd $NEW_USER_QNX');
+  echo \"* If OSS folder '$OSS_FOLDER' exists (which should exist), change its owner to '$NEW_USER_QNX'. *\";
+  su -c 'chown -R '$NEW_USER_QNX' $OSS_FOLDER';
+  ls -lh $OSS_FOLDER;
+  "
+
+read -p "Run the command @ $hostname (y/n)? "
+if [ "$REPLY" == "y" ]; then
+    ssh $rootuser_qnx@$hostname -t $commands 2>&1 | tee /tmp/robot-create-user-`date +"%Y%m%d-%H%M%S"`.log
+    echo "====="
+else
+    echo "DO NOT RUN"
+    echo "----"
+    echo "$commands"
+    echo "----"
+    echo "EXITTING.."
+fi
+
+rm -fr ${TMPDIR}


### PR DESCRIPTION
Please DO NOT MERGE YET. 
Being tested now.
- [x] Install NXO model.
- [x] For Hiro, respect models that are already installed.
- [x] Install OSS controller into `/opt/jsk`, categorized per version (`/opt/jsk/%VERSION%`). Create symlink from /opt/jsk to the appropriate version.
- [ ] Integrate running `robot-install-qnx-%MAC_ADDR_QNX% %HOST_QNX% %USER_QNX%` (discussed https://github.com/tork-a/delivery/issues/33#issuecomment-67120688)
- [x] Create tork user if it not exists (on Hironx only. On NXO it should exist).
- [ ] For NXO, embed the password of `tork` user so that the user doesn't need to know its password, let alone type it in.
- [x] this doesn't have to be made soon but update existing symlinks. e.g. if `/opt/jsk/bin --> /opt/jsk/315.2.7/bin` exists and new hrpsys getting installed is `315.2.8`, after runing the command we want:
  
   `/opt/jsk/bin --> /opt/jsk/315.2.8/bin`
   `/opt/jsk/315.2.7/bin`
   :
   `/opt/jsk/315.2.8/bin`
   :
