### PR TITLE
[hironx_ros_bridge] hironx_ros_bridge.launch: collision detector use com...

### DIFF
--- a/hironx_ros_bridge/launch/hironx_ros_bridge.launch
+++ b/hironx_ros_bridge/launch/hironx_ros_bridge.launch
@@ -45,5 +45,6 @@
     <arg name="corbaport" default="$(arg corbaport)" />
     <arg name="nameserver" value="$(arg nameserver)" />
     <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
+    <arg name="COLLISIONDETECTOR_INSTANCE_NAME" default="CollisionDetector0" />
   </include>
 </launch>


### PR DESCRIPTION
...ponent, not plugin so instance name is not co, but CollisionDetector

as comment at https://github.com/k-okada/rtmros_hironx/blob/08e1fae2ad34fc6fe5d6db0f31cdc5550d202e80/hironx_ros_bridge/launch/hironx_ros_bridge.launch#L40 says `Collision detection here runs external to the robot (on Ubuntu) and 
       visualizes the distance between each links.` it uses collision detection runs on ubuntu machine, not inside of rtcd  (plugin), so I'm not sure why. add comment at https://github.com/start-jsk/rtmros_common/commit/6e4447af4099375cfe8bbbdbf89bfa3c4e7a0ecf#commitcomment-9563584
