### PR TITLE
(robot) Add fetch script for the OSS log files on QNX

### DIFF
--- a/hironx_ros_bridge/robot/qnx_fetch_log.sh
+++ b/hironx_ros_bridge/robot/qnx_fetch_log.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+function usage {
+    echo >&2 "usage: $0 [hostname (default:hiro019)]"
+    echo >&2 "          [-h|--help] Print help message."
+    exit 0
+}
+
+# command line parse. If the num of argument is not as expected, call usage func.
+OPT=`getopt -o h -l help -- $*`
+if [ $# != 1 ]; then
+    usage
+fi
+
+eval set -- $OPT
+
+while [ -n "$1" ] ; do
+    case $1 in
+        -h|--help) usage ;;
+        --) shift; break;;
+        *) echo "Unknown option($1)"; usage;;
+    esac
+done
+
+hostname=$1
+hostname=${hostname:="hiro019"} 
+ossuser_qnx="tork"
+OSS_FOLDER='/opt/jsk'
+OSS_FOLDER_LOG=${OSS_FOLDER}/var/log
+DATE=`date +"%Y%m%d-%H%M%S"`
+TMP_FOLDER_ROOT=/tmp/HiroNXO_Log
+NAME_LOGFILE=${TMP_FOLDER_ROOT}/qnx_fetch_log_${hostname}_${DATE}.log
+
+mkdir ${TMP_FOLDER_ROOT}
+
+# Command that gets run on QNX. 
+# - (Assumes remotely logged in to qnx via ssh)
+# - Create tarball of /opt/jsk/var/log/* at /home/tork
+# - Log out of QNX
+# - scp the tarball
+commands="
+  . ~/.profile || echo '~/.profile does not exist. Move on anyway.';
+  env;
+  trap 'exit 1' ERR;
+  set +x;
+
+  echo '* Create tarball of ${OSS_FOLDER_LOG} *';
+  tar cfvz opt_jsk_var_logs_${DATE}.tgz ${OSS_FOLDER_LOG}/* || echo '* Failed to create tarball *';
+
+  echo '* Exitting ssh session to QNX. *';
+  exit;
+  "
+
+IS_SUCCESS=1
+
+read -p "Run the command @ $hostname (y/n)? "
+if [ "$REPLY" == "y" ]; then
+    ssh $ossuser_qnx@$hostname -t $commands 2>&1 | tee ${NAME_LOGFILE}
+    echo "====="
+    scp $ossuser_qnx@$hostname:/home/$ossuser_qnx/opt_jsk_var_logs_${DATE}.tgz . | tee ${NAME_LOGFILE}
+
+    IS_SUCCESS=0
+else
+    echo "DO NOT RUN"
+    echo "----"
+    echo "$commands"
+    echo "----"
+    echo "EXITTING.."
+fi
+
+if [ "${IS_SUCCESS}" -eq 1 ]; then
+    echo "Operation unsuccessful. Send back log file: ${NAME_LOGFILE}"
+fi


### PR DESCRIPTION
A mitigation to https://github.com/start-jsk/hironx-package/issues/83.

Often times we need to look at the OSS controller's log files that are stored on QNX. Asking the end users of the robot to run the sequence of the linux commands to log on to QNX, zip the log folder and so on is undesirable. This small script lessens such a pain by automating the following:
- Log on to QNX, create a tarball of `/opt/jsk/var/log/*`
- Logout of QNX then fetch the tarball by scp

You can run by:

```
Ubuntu$ ./qnx_fetch_log.sh hiro130

 (or)

Ubuntu$ rosrun hironx_ros_bridge qnx_fetch_log.sh hiro130
```

Result should look like this. 

```
mkdir: cannot create directory ‘/tmp/HiroNXO_Log’: File exists
Run the command @ hiro130 (y/n)? y
tork@hiro130's password: 
edit the file .profile if you want to change your environment.
To start the Photon windowing environment, type "ph".
_=/usr/bin/env
SSH_CONNECTION=192.168.196.1 34694 hiro130 22
PATH=/usr/bin:/bin:/usr/sbin:/sbin
SHELL=/bin/sh
TERM=xterm
USER=tork
MAIL=/var/spool/mail/tork
HOME=/home/tork
SSH_CLIENT=192.168.196.1 34694 22
SSH_TTY=/dev/ttyp3
LOGNAME=tork
* Create tarball of /opt/jsk/var/log *
tar: Removing leading `/' from member names
/opt/jsk/var/log/ModelLoader.log.dummy
/opt/jsk/var/log/rtcd.log.dummy
* Exitting ssh session to QNX. *
Connection to hiro130 closed.
=====
tork@hiro130's password: 
```

Result will be a `.tgz` file.
