### PR TITLE
Increase test limit time according to pass hrpsys-base travis easily

### DIFF
--- a/hironx_ros_bridge/test/test-hironx-ros-bridge-pose.test
+++ b/hironx_ros_bridge/test/test-hironx-ros-bridge-pose.test
@@ -10,6 +10,6 @@
     <arg name="corbaport" value="$(arg corbaport)" />
   </include>
 
-  <test type="test_hironx_ros_bridge_pose.py" pkg="hironx_ros_bridge" test-name="test_hironx_ros_bridge_pose" time-limit="200" retry="2"
+  <test type="test_hironx_ros_bridge_pose.py" pkg="hironx_ros_bridge" test-name="test_hironx_ros_bridge_pose" time-limit="700" retry="2"
         args="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService" />
 </launch>


### PR DESCRIPTION
Increase test limit time according to pass hrpsys-base travis testing easily
according to the discussion : https://github.com/fkanehiro/hrpsys-base/pull/723#issuecomment-122649530

The travis error says:

```
<testsuite errors="1" failures="0" name="unittest.suite.TestSuite" tests="1" time="654.356">
  <testcase classname="rostest.runner.RosTest" name="testtest_hironx_ros_bridge_pose" time="654.3554">
    <error type="RLTestTimeoutException">test max time allotted
  File "/usr/lib/python2.7/unittest/case.py", line 327, in run
    testMethod()
  File "/opt/ros/hydro/lib/python2.7/dist-packages/rostest/runner.py", line 146, in fn
    self.test_parent.run_test(test)
  File "/opt/ros/hydro/lib/python2.7/dist-packages/rostest/rostest_parent.py", line 91, in run_test
    return self.runner.run_test(test)
  File "/opt/ros/hydro/lib/python2.7/dist-packages/roslaunch/launch.py", line 669, in run_test
    raise RLTestTimeoutException("test max time allotted")
    </error>
  </testcase>
  <system-out><![CDATA[[ROSTEST]setup[/opt/ros/hydro/share/hironx_ros_bridge/test/test-hironx-ros-bridge-pose.test] run_id[07fef250-2df7-11e5-9e4b-898626e31d9d] starting
�[1mstarted roslaunch server http://testing-worker-linux-89e97461-1-14451-linux-15-71622469:37822/�[0m
```

So I increased time limit 700 (>= 654.356).
(It may involve the time both to check all test and to shut down test.)
