### PR TITLE
Increase retry number to pass travis test

### DIFF
--- a/hironx_ros_bridge/test/test-hironx-ros-bridge-controller.test
+++ b/hironx_ros_bridge/test/test-hironx-ros-bridge-controller.test
@@ -10,6 +10,6 @@
     <arg name="corbaport" value="$(arg corbaport)" />
   </include>
 
-  <test type="test_hironx_ros_bridge_controller.py" pkg="hironx_ros_bridge" test-name="test_hironx_ros_bridge_controller" time-limit="200" retry="2"
+  <test type="test_hironx_ros_bridge_controller.py" pkg="hironx_ros_bridge" test-name="test_hironx_ros_bridge_controller" time-limit="200" retry="4"
         args="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService" />
 </launch>

--- a/hironx_ros_bridge/test/test-hironx-ros-bridge-pose.test
+++ b/hironx_ros_bridge/test/test-hironx-ros-bridge-pose.test
@@ -10,6 +10,6 @@
     <arg name="corbaport" value="$(arg corbaport)" />
   </include>
 
-  <test type="test_hironx_ros_bridge_pose.py" pkg="hironx_ros_bridge" test-name="test_hironx_ros_bridge_pose" time-limit="700" retry="2"
+  <test type="test_hironx_ros_bridge_pose.py" pkg="hironx_ros_bridge" test-name="test_hironx_ros_bridge_pose" time-limit="700" retry="4"
         args="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService" />
 </launch>


### PR DESCRIPTION
Increase retry number of rostest files.
Recently travis test of hrpsys-base sometimes failes:
https://github.com/fkanehiro/hrpsys-base/pull/723
https://github.com/fkanehiro/hrpsys-base/pull/729

We are trying to improve by fixing hrpsys-base source (https://github.com/fkanehiro/hrpsys-base/pull/729), 
but some situations on hrpsys-base `315_1_10` cannot be fixed. 
So I increased retry number of rostest files which frequently failed.
