### PR TITLE
Initialize hcf in setUpClass to enable retrying during hcf initialization.

### DIFF
--- a/hironx_ros_bridge/test/test_hironx_ros_bridge.py
+++ b/hironx_ros_bridge/test/test_hironx_ros_bridge.py
@@ -45,11 +45,10 @@ class TestHiroROSBridge(unittest.TestCase):
         self.filename_base = tempfile.mkstemp()[1]
         self.filenames = []
 
-        self.robot = hironx.HIRONX()
-        self.robot.init()
-
     @classmethod
     def setUpClass(self):
+        self.robot = hironx.HIRONX()
+        self.robot.init()
 
         self.listener = tf.TransformListener()
 


### PR DESCRIPTION
Initialize hcf in setUpClass to enable retrying during hcf initialization to pass travis tests.

Currently, hrpsys-base tests fail frequently on hironx_ros_bridge checking.
In the log(https://s3.amazonaws.com/archive.travis-ci.org/jobs/72416107/log.txt),
hcf initializaion fails, but rostest seems not to be retried. 
The error message says like this:

```
FAILURE: test [test_hironx_ros_bridge_controller] did not generate test results
  File "/usr/lib/python2.7/unittest/case.py", line 327, in run
    testMethod()
  File "/opt/ros/hydro/lib/python2.7/dist-packages/rostest/runner.py", line 162, in fn
    self.assert_(os.path.isfile(test_file), "test [%s] did not generate test results"%test_name)
  File "/usr/lib/python2.7/unittest/case.py", line 420, in assertTrue
    raise self.failureException(msg)
```

Here is corresponding code for rostest:http://code.metager.de/source/xref/ros/comm/tools/rostest/src/rostest/runner.py#161
rostest does not go to retry section (results.num_errors or results.num_failures).

I checked these two cases:
- case1  
  Add intentionally error codes to test_hironx_ros_bridge.py `setUpClass` like this:

```
    def setUpClass(self):
           aaaaaa # for NameError: global name 'aaaaaa' is not defined
```

By executing the following command, I confirmed that rostest failed and retried testing:

```
rostest hironx_ros_bridge test-hironx-ros-bridge-controller.test
```
- case 2  
  Add intentionally error codes to test_hironx_ros_bridge.py `__init__` like this:

```
    def __init__(self, *args, **kwargs):
           aaaaaa # for NameError: global name 'aaaaaa' is not defined
```

By executing the following command, I confirmed that rostest failed and rostest are not retried:

```
rostest hironx_ros_bridge test-hironx-ros-bridge-controller.test
```

In the original hrpsys-base travis log, error occurs in  `__init__` function:
https://s3.amazonaws.com/archive.travis-ci.org/jobs/72416107/log.txt
Therefore, retrying  of `test-hironx-ros-bridge-controller.test` was not executed. 
