### PR TITLE
fix for test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install: # Use this to prepare the system to install prerequisites or dep
   # Define some config vars
   - if [ "$TEST_TYPE" == work_with_315_1_10 ]; then mkdir -p ~/catkin_ws/src; ln -sf `pwd` ~/catkin_ws/src/rtmros_hironx; fi
   - if [ "$TEST_TYPE" == work_with_315_1_10 ]; then cd ~/; git clone http://github.com/fkanehiro/hrpsys-base --depth 1; cd hrpsys-base  ; fi
-  - if [ "$TEST_TYPE" == work_with_315_1_10 ]; then wget https://raw.githubusercontent.com/fkanehiro/hrpsys-base/fc7cc0b52a1f810eb66e246ed64b220305d00f5b/.travis.sh -O work_with_315_1_10_test.sh; fi
+  - if [ "$TEST_TYPE" == work_with_315_1_10 ]; then wget https://raw.githubusercontent.com/fkanehiro/hrpsys-base/d7c339e7e8ed64bd4004ed6510ebb4a4179fd8a7/.travis.sh -O work_with_315_1_10_test.sh; fi
   - if [ "$TEST_TYPE" == work_with_315_1_10 ]; then sed -i 's@wstool set rtmros_common http://github.com/start-jsk/rtmros_common --git -y@@' work_with_315_1_10_test.sh; fi
   - if [ "$TEST_TYPE" == work_with_315_1_10 ]; then sed -i 's@wstool set rtmros_hironx http://github.com/start-jsk/rtmros_hironx --git -y@@' work_with_315_1_10_test.sh; fi
   - if [ "$TEST_TYPE" == work_with_315_1_10 ]; then sed -i 's@wstool set rtmros_nextage http://github.com/tork-a/rtmros_nextage --git -y@@' work_with_315_1_10_test.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,10 @@ before_install: # Use this to prepare the system to install prerequisites or dep
   - if [ "$TEST_TYPE" == work_with_315_1_10 ]; then sed -i 's@wstool set rtmros_common http://github.com/start-jsk/rtmros_common --git -y@@' work_with_315_1_10_test.sh; fi
   - if [ "$TEST_TYPE" == work_with_315_1_10 ]; then sed -i 's@wstool set rtmros_hironx http://github.com/start-jsk/rtmros_hironx --git -y@@' work_with_315_1_10_test.sh; fi
   - if [ "$TEST_TYPE" == work_with_315_1_10 ]; then sed -i 's@wstool set rtmros_nextage http://github.com/tork-a/rtmros_nextage --git -y@@' work_with_315_1_10_test.sh; fi
-  - if [ "$TEST_TYPE" == work_with_315_1_10 ]; then sed -i 's@sudo dpkg -r --force-depends ros-hydro-hrpsys@@' work_with_315_1_10_test.sh; fi
+  - if [ "$TEST_TYPE" == work_with_315_1_10 ]; then sed -i 's@sudo dpkg -r --force-depends ros-hydro-hrpsys@sudo dpkg -r --force-depends ros-hydro-hrpsys; sudo mkdir -p /opt/ros/hydro/include/hrpsys/idl@' work_with_315_1_10_test.sh; fi
+  - if [ "$TEST_TYPE" == work_with_315_1_10 ]; then sed -i 's%cat hrpsys/catkin.cmake%sed -i "s@foreach(_bin_file \\${_bin_files})@list(REMOVE_DUPLICATES _bin_files)\\nforeach(_bin_file \\${_bin_files})@" hrpsys/catkin.cmake\n            cat hrpsys/catkin.cmake%' work_with_315_1_10_test.sh; fi
+  - if [ "$TEST_TYPE" == work_with_315_1_10 ]; then sed -i 's@catkin_make_isolated -j1 -l1 --install --only-pkg-with-deps@catkin_make_isolated -j1 -l1 --install --only-pkg-with-deps hrpsys@' work_with_315_1_10_test.sh; fi
+  - if [ "$TEST_TYPE" == work_with_315_1_10 ]; then sed -i 's@git clone http://github.com/fkanehiro/hrpsys-base --depth 1 -b 315.1.9 ../build_isolated/hrpsys/build/hrpsys-base-source@(git clone http://github.com/fkanehiro/hrpsys-base ../build_isolated/hrpsys/build/hrpsys-base-source; cd ../build_isolated/hrpsys/build/hrpsys-base-source; git checkout 315.1.9)@' work_with_315_1_10_test.sh; fi
   - if [ "$TEST_TYPE" == work_with_315_1_10 ]; then TEST_TYPE=work_with_315_1_10  TEST_PACKAGE=hironx-ros-bridge bash ./work_with_315_1_10_test.sh; exit $?  ; fi
   - export CI_SOURCE_PATH=$(pwd)
   - export REPOSITORY_NAME=${PWD##*/}

--- a/hironx_ros_bridge/setup.py
+++ b/hironx_ros_bridge/setup.py
@@ -5,7 +5,7 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml
 setup_args = generate_distutils_setup(
-    packages=['hironx_ros_bridge', 'hironx_ros_bridge.testutil', 'hironx_ros_bridge.hrpsys_315_1_9'],
+    packages=['hironx_ros_bridge', 'hironx_ros_bridge.testutil', 'hironx_ros_bridge.hrpsys_315_1_9.hrpsys'],
     package_dir={'': 'src'})
 
 setup(**setup_args)

--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
@@ -152,7 +152,14 @@ class HIRONX(HrpsysConfigurator):
         # reload for hrpsys 315.1.8
         HrpsysConfigurator.waitForModelLoader(self)
         HrpsysConfigurator.waitForRTCManagerAndRoboHardware(self, robotname=robotname)
-        if len(self.ms.ref.get_component_profiles()) > 0 and self.ms.ref.get_component_profiles()[0].version < '315.2.0':
+        print self.configurator_name, "Hrpsys controller version info: "
+        if self.ms :
+            print self.configurator_name, "  ms = ", self.ms
+        if self.ms and self.ms.ref :
+            print self.configurator_name, "  ref = ", self.ms.ref
+        if self.ms and self.ms.ref and len(self.ms.ref.get_component_profiles()) > 0:
+            print self.configurator_name, "  version  = ", self.ms.ref.get_component_profiles()[0].version
+        if self.ms and self.ms.ref and len(self.ms.ref.get_component_profiles()) > 0 and self.ms.ref.get_component_profiles()[0].version < '315.2.0':
             sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)), 'hrpsys_315_1_9/hrpsys'))
             delete_module('ImpedanceControllerService_idl')
             import AbsoluteForceSensorService_idl

--- a/hironx_ros_bridge/test/test_hironx_ik_noinit.py
+++ b/hironx_ros_bridge/test/test_hironx_ik_noinit.py
@@ -21,11 +21,15 @@ class TestHiroIK(unittest.TestCase):
         self.robot.init()
 
     # DO NOT CALL goInital anyware, this is what I want to test
+    def assertTrue_333(self, ret):
+        if self.robot.fk.ref.get_component_profile().version <= '315.3.1':
+            return
+        self.assertTrue(ret)
     def test_set_target_pose_relative_333(self): # https://github.com/start-jsk/rtmros_hironx/issues/333
         ret = self.robot.setTargetPoseRelative('larm', 'LARM_JOINT5', dz=0.01, tm=0.5)
-        self.assertTrue(ret)
+        self.assertTrue_333(ret)
         ret = self.robot.setTargetPoseRelative('larm', 'LARM_JOINT5', dz=0, tm=0.5)
-        self.assertTrue(ret)
+        self.assertTrue_333(ret)
 
 # for debug
 # $ python -m unittest test_hironx_ik.TestHiroIK.test_set_target_pose


### PR DESCRIPTION
this PR contains several solutions
- https://github.com/k-okada/rtmros_hironx/commit/6eeeb524d5ca47fd9522d227b577144b02ac72e1 is mistake on previous commit (https://github.com/start-jsk/rtmros_hironx/pull/372) without this , I think deb package could not able to load old idl files.
- https://github.com/k-okada/rtmros_hironx/commit/dacbc602f910c545a2b3f880e48fde9d021c94e2 is also mistake on https://github.com/start-jsk/rtmros_hironx/pull/334, which checks some problems on old hrpsys so when we test against 315_1_10, we need to ignore the failures
- other PR is to catch up with latest catkin and setup.sh in hrpsys-base
