### PR TITLE
Reduce rostest time-limit according to actual travis execution time.

### DIFF
--- a/hironx_ros_bridge/test/test-hironx-ros-bridge-controller.test
+++ b/hironx_ros_bridge/test/test-hironx-ros-bridge-controller.test
@@ -7,6 +7,6 @@
     <arg name="corbaport" value="$(arg corbaport)" />
   </include>
 
-  <test type="test_hironx_ros_bridge_controller.py" pkg="hironx_ros_bridge" test-name="test_hironx_ros_bridge_controller" time-limit="200" retry="4"
+  <test type="test_hironx_ros_bridge_controller.py" pkg="hironx_ros_bridge" test-name="test_hironx_ros_bridge_controller" time-limit="100" retry="4"
         args="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService" />
 </launch>

--- a/hironx_ros_bridge/test/test-hironx-ros-bridge-pose.test
+++ b/hironx_ros_bridge/test/test-hironx-ros-bridge-pose.test
@@ -7,6 +7,6 @@
     <arg name="corbaport" value="$(arg corbaport)" />
   </include>
 
-  <test type="test_hironx_ros_bridge_pose.py" pkg="hironx_ros_bridge" test-name="test_hironx_ros_bridge_pose" time-limit="700" retry="4"
+  <test type="test_hironx_ros_bridge_pose.py" pkg="hironx_ros_bridge" test-name="test_hironx_ros_bridge_pose" time-limit="240" retry="4"
         args="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService" />
 </launch>

--- a/hironx_ros_bridge/test/test-hironx-ros-bridge.test
+++ b/hironx_ros_bridge/test/test-hironx-ros-bridge.test
@@ -12,6 +12,6 @@
   <param name="joint_states_test/hzerror" value="10" />
   <param name="joint_states_test/test_duration" value="5.0" />
 
-  <test test-name="joint_states_test" pkg="rostest" type="hztest" name="joint_states_test" />
+  <test test-name="joint_states_test" pkg="rostest" type="hztest" name="joint_states_test" time-limit="100"/>
 
 </launch>


### PR DESCRIPTION
Reduce rostest time-limit according to actual travis execution time.

Original discussion is https://github.com/fkanehiro/hrpsys-base/pull/799.
Currently, 15th and 16th travis test on fkanehiro/hrpsys-base frequently fail because hironx_ros_bridge tests take a long time.

I checked the success logs:
https://s3.amazonaws.com/archive.travis-ci.org/jobs/79412807/log.txt
https://s3.amazonaws.com/archive.travis-ci.org/jobs/79412808/log.txt
https://s3.amazonaws.com/archive.travis-ci.org/jobs/79511665/log.txt
https://s3.amazonaws.com/archive.travis-ci.org/jobs/79511666/log.txt

Execution durations of each rostest are:

```
start: test_hironx_ros_bridge_controller
 30sec
 18sec
 15sec
 31sec
start: test_hironx
 4min39sec
 3min55sec
 3min11sec
 4min20sec
start: test_hironx_ros_bridge_pose
 1min55sec
 1min37sec
 1min37sec
 1min52sec
start: test_hironx_ros_bridge
 27sec
 12sec
 12sec
 28sec
start: test_hironx_ros_bridge_send
 2min20sec
 2min6sec
 2min6sec
 2min21sec
```

Based on the actual travis execution time, I reduce some rostest time-limit.
All reduced time-limits are larger than twice of actual execution time. 
("twice" is margin)
- test-hironx-ros-bridge-controller.test  
  Reduce 200sec ->100sec  
  Max 31sec -> twice 62sec -> margined 100sec
-  test-hironx-ros-bridge-pose.test  
  Reduce 700sec -> 240sec  
  Max 115sec -> twice 230sec -> margined 240sec
- test-hironx-ros-bridge.test  
  Increase 60sec -> 100sec  
  Max 28 sec -> twice 56sec -> margined 100sec
