### PR TITLE
Add smaller .rosinstall file

### DIFF
--- a/.rosinstall_min
+++ b/.rosinstall_min
@@ -1,0 +1,4 @@
+- git:
+    uri: https://github.com/start-jsk/rtmros_hironx
+    local-name: rtm-ros-robotics/rtmros_hironx
+    version: hydro-devel


### PR DESCRIPTION
I noticed that the currently available `.rosinstall` file in this repository includes `hrpsys` as a source build target. I assume that most of Hiro / NXO users may not need the latest `hrpsys` feature on Ubuntu, so it's excluded in this PR.

People who'll choose to keep using ROS Hydro will have to build from source.
Related: https://github.com/start-jsk/rtmros_hironx/issues/202
