### PR TITLE
Add missing install rule for calibration pkg

### DIFF
--- a/hironx_calibration/CMakeLists.txt
+++ b/hironx_calibration/CMakeLists.txt
@@ -10,3 +10,6 @@ install(DIRECTORY capture_data estimate_params # view_results
   USE_SOURCE_PERMISSIONS
 )
 
+install(FILES upload_urdf.launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)


### PR DESCRIPTION
- Adding missing launch
- <s>Add Kinect to the default URDF so that users won't have to add it on their own (http://wiki.ros.org/rtmros_nextage/Tutorials/CalibrateKinect#Before_Calibration). 
  - Confirmed that this model works even whithout calibration</s>
