### PR TITLE
[hydro-devel, .travis.yml] Convert each entry in .rosinstall into a single line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ install: # Use this to install any prerequisites or dependencies necessary to ru
   - if [ $USE_DEB == false ]; then $ROSWS merge file://$CI_SOURCE_PATH/.rosinstall      ; fi
   ##
   - if [ $USE_DEB == false -o $BUILDER == rosbuild ]; then if [ $ROSWS == rosws ]; then $ROSWS merge /opt/ros/$ROS_DISTRO/.rosinstall; fi  ; fi
+  - if [ $USE_DEB == false ]; then python -c 'import sys, yaml; yaml.dump(yaml.load(sys.stdin), sys.stdout, width=1024, indent=4)'  < .rosinstall > .rosinstall.$$; mv .rosinstall.$$ .rosinstall; fi
   - if [ $USE_DEB == false ]; then sed -i "s@^\(.*github.com/$TRAVIS_REPO_SLUG.*\)@#\1@" .rosinstall               ; fi # comment out current repo
   - if [ $USE_DEB == false ]; then $ROSWS update   ; fi
   # disable doc generation


### PR DESCRIPTION
Cherry-picking  a commit from https://github.com/start-jsk/rtmros_hironx/pull/403 that was targeted at `indigo-devel`. 

wstool fails on travis for hydro-devel too. e.g. at [these lines](https://travis-ci.org/start-jsk/rtmros_hironx/jobs/88474513#L374-L377) (in https://github.com/start-jsk/rtmros_hironx/pull/397).
