### PR TITLE
Improve hironxo dashboard

### DIFF
--- a/hironx_ros_bridge/resource/hironx_commandpanel_main.ui
+++ b/hironx_ros_bridge/resource/hironx_commandpanel_main.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>557</width>
-    <height>255</height>
+    <height>271</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,9 +15,9 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="5,5">
+    <layout class="QHBoxLayout" name="horizontalLayout_top" stretch="5,5">
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,1">
+      <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0">
        <property name="spacing">
         <number>6</number>
        </property>
@@ -31,128 +31,160 @@
         <number>1</number>
        </property>
        <item>
-        <widget class="QPushButton" name="pushButton_checkEncoders">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;HIRONX.checkEncoders&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Calibration</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="gridLayout_2" rowstretch="0" columnstretch="7,3">
+        <layout class="QGridLayout" name="gridLayout_2" rowstretch="0" columnstretch="0">
          <item row="0" column="0">
-          <layout class="QVBoxLayout" name="verticalLayout_4">
+          <layout class="QVBoxLayout" name="verticalLayout_init_off_pose_top" stretch="1,1,2">
            <item>
-            <widget class="QPushButton" name="pushButton_goInitial">
+            <widget class="QLabel" name="label_sectiontitle_init_off_pose">
+             <property name="text">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Init/Off Operations&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pushButton_checkEncoders">
              <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;HIRONX.goInitial&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;HIRONX.checkEncoders&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="text">
-              <string>Goto init pose</string>
+              <string>Joint calibration</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QPushButton" name="pushButton_goInitial_factoryval">
-             <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;HIRONX.goInitial(init_pose_type=&lt;span style=&quot; font-family:'Courier New,courier';&quot;&gt;_InitialPose_Factory)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="text">
-              <string>Goto init pose (factory)</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="pushButton_goOffPose">
-             <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;goOffPose&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="text">
-              <string>Goto power-off pose</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="0" column="1">
-          <layout class="QVBoxLayout" name="verticalLayout_5">
-           <item>
-            <widget class="QLabel" name="label_duration">
-             <property name="text">
-              <string>Duration (sec)</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QDoubleSpinBox" name="doubleSpinBox_duration">
-             <property name="toolTip">
-              <string>Set the time (second) to complete the operation.</string>
-             </property>
-             <property name="decimals">
-              <number>1</number>
-             </property>
-             <property name="minimum">
-              <double>2.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>7.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="label_spacer_1">
-             <property name="text">
-              <string/>
-             </property>
-            </widget>
+            <layout class="QHBoxLayout" name="horizontalLayout_init_off_operations" stretch="5,5">
+             <item>
+              <layout class="QVBoxLayout" name="verticalLayout_init_off_operations_buttons">
+               <item>
+                <widget class="QPushButton" name="pushButton_goInitial">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;HIRONX.goInitial&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Goto init pose</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="pushButton_goInitial_factoryval">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;HIRONX.goInitial(init_pose_type=&lt;span style=&quot; font-family:'Courier New,courier';&quot;&gt;_InitialPose_Factory)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Goto init pose (factory)</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="pushButton_goOffPose">
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;goOffPose&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Goto power-off pose</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="verticalLayout_5">
+               <item>
+                <widget class="QLabel" name="label_duration">
+                 <property name="text">
+                  <string>Duration (sec)</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QDoubleSpinBox" name="doubleSpinBox_duration">
+                 <property name="toolTip">
+                  <string>Set the time (second) to complete the operation.</string>
+                 </property>
+                 <property name="decimals">
+                  <number>1</number>
+                 </property>
+                 <property name="minimum">
+                  <double>2.000000000000000</double>
+                 </property>
+                 <property name="value">
+                  <double>7.000000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_spacer_1">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
            </item>
           </layout>
          </item>
         </layout>
        </item>
        <item>
-        <layout class="QGridLayout" name="gridLayout_impedance" rowstretch="0" columnstretch="6,4">
+        <layout class="QGridLayout" name="gridLayout_impedance" rowstretch="0" columnstretch="0">
          <item row="0" column="0">
-          <layout class="QVBoxLayout" name="verticalLayout_3">
+          <layout class="QVBoxLayout" name="verticalLayout_impedance">
            <item>
-            <widget class="QPushButton" name="pushButton_startImpedance">
-             <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;startImpedance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
+            <widget class="QLabel" name="label_sectiontitle_impedance">
              <property name="text">
-              <string>Impedance start</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Impedance control&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QPushButton" name="pushButton_stopImpedance">
-             <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;stopImpedance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <layout class="QHBoxLayout" name="horizontalLayout_impedance_armselect">
+             <property name="leftMargin">
+              <number>1</number>
              </property>
-             <property name="text">
-              <string>Impedance stop</string>
+             <property name="rightMargin">
+              <number>1</number>
              </property>
-            </widget>
+             <item>
+              <widget class="QRadioButton" name="radioButton_impedance_left">
+               <property name="text">
+                <string>Left arm</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="radioButton_impedance_right">
+               <property name="text">
+                <string>Right arm</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
-          </layout>
-         </item>
-         <item row="0" column="1">
-          <layout class="QVBoxLayout" name="verticalLayout_6">
            <item>
-            <widget class="QRadioButton" name="radioButton_impedance_left">
-             <property name="text">
-              <string>Left arm</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="radioButton_impedance_right">
-             <property name="text">
-              <string>Right arm</string>
-             </property>
-            </widget>
+            <layout class="QHBoxLayout" name="horizontalLayout_impedance_operation">
+             <item>
+              <widget class="QPushButton" name="pushButton_startImpedance">
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;startImpedance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string>Start</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="pushButton_stopImpedance">
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;stopImpedance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string>Stop</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
           </layout>
          </item>

--- a/hironx_ros_bridge/resource/hironx_commandpanel_main.ui
+++ b/hironx_ros_bridge/resource/hironx_commandpanel_main.ui
@@ -195,14 +195,70 @@
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <widget class="QPushButton" name="pushButton_actualPose">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;actualPose&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Current actual pose</string>
-         </property>
-        </widget>
+        <layout class="QVBoxLayout" name="verticalLayout_getpose">
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <widget class="QLabel" name="label_sectiontitle_currentpose">
+             <property name="text">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;View current pose&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_degree_order" stretch="7,3">
+           <item>
+            <widget class="QLabel" name="label_precision_output">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Order of degree in the returned values in the result. Default: 4 &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Order degree&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="spinBox_precision_output">
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>20</number>
+             </property>
+             <property name="value">
+              <number>4</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <widget class="QPushButton" name="pushButton_actualPose_l">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;actualPose&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>L-arm</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pushButton_actualPose_r">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;actualPose&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>R-arm</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
        </item>
        <item>
         <widget class="QPushButton" name="pushButton_groups">
@@ -215,11 +271,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QListView" name="listView_output">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(Commands and their output are to be printed here)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-        </widget>
+        <widget class="QTextBrowser" name="textBrowser_output"/>
        </item>
       </layout>
      </item>

--- a/hironx_ros_bridge/resource/hironx_commandpanel_main.ui
+++ b/hironx_ros_bridge/resource/hironx_commandpanel_main.ui
@@ -58,7 +58,7 @@
                <item>
                 <widget class="QPushButton" name="pushButton_goInitial">
                  <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;HIRONX.goInitial&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Using HIRONX.goInitial, all joints move to the pre-defined initial pose.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                  <property name="text">
                   <string>Goto init pose</string>
@@ -78,7 +78,7 @@
                <item>
                 <widget class="QPushButton" name="pushButton_goOffPose">
                  <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;goOffPose&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Using HIRONX.goOffPose, all joints move to the pose that is the safest and you can turn off the power of the robot.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                  <property name="text">
                   <string>Goto power-off pose</string>
@@ -239,7 +239,7 @@
            <item>
             <widget class="QPushButton" name="pushButton_actualPose_l">
              <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;actualPose&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Shows the pose of the eef w.r.t the waist link.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="text">
               <string>L-arm</string>
@@ -249,7 +249,7 @@
            <item>
             <widget class="QPushButton" name="pushButton_actualPose_r">
              <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;actualPose&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Shows the pose of the eef w.r.t the waist link.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="text">
               <string>R-arm</string>
@@ -263,7 +263,7 @@
        <item>
         <widget class="QPushButton" name="pushButton_groups">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Groups&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Shows the kinematic groups and elements of each group.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="text">
           <string>Show kinematic groups</string>

--- a/hironx_ros_bridge/resource/hironx_commandpanel_main.ui
+++ b/hironx_ros_bridge/resource/hironx_commandpanel_main.ui
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>command_widget_top</class>
+ <widget class="QWidget" name="command_widget_top">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>557</width>
+    <height>284</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Command Panel for Hironx / NEXTAGE Open</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="5,5">
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,1,1,1,1">
+       <property name="spacing">
+        <number>6</number>
+       </property>
+       <property name="sizeConstraint">
+        <enum>QLayout::SetMinimumSize</enum>
+       </property>
+       <property name="topMargin">
+        <number>1</number>
+       </property>
+       <property name="bottomMargin">
+        <number>1</number>
+       </property>
+       <item>
+        <widget class="QPushButton" name="pushButton_checkEncoders">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;HIRONX.checkEncoders&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Calibration</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0" columnstretch="7,0,3">
+         <item row="2" column="0">
+          <layout class="QVBoxLayout" name="verticalLayout_4">
+           <item>
+            <widget class="QPushButton" name="pushButton_goInitial">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;HIRONX.goInitial&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>Goto init pose</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pushButton_goInitial_factoryval">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;HIRONX.goInitial(init_pose_type=&lt;span style=&quot; font-family:'Courier New,courier';&quot;&gt;_InitialPose_Factory)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>Goto init pose (factory)</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pushButton_goOffPose">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;goOffPose&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>Goto power-off pose</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="2" column="2">
+          <layout class="QVBoxLayout" name="verticalLayout_5">
+           <item>
+            <widget class="QLabel" name="label_duration">
+             <property name="text">
+              <string>Duration (sec)</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QDoubleSpinBox" name="doubleSpinBox_duration">
+             <property name="toolTip">
+              <string>Set the time (second) to complete the operation.</string>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="minimum">
+              <double>2.000000000000000</double>
+             </property>
+             <property name="value">
+              <double>7.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_spacer_1">
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButton_servoOn">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;servoOn&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Servos on</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButton_servoOff">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;servoOff&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Servos off</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButton_startImpedance">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;startImpedance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Impedance start</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButton_stopImpedance">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;stopImpedance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Impedance stop</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QPushButton" name="pushButton_actualPose">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;actualPose&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Current actual pose</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButton_groups">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Groups&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Show kinematic groups</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QListView" name="listView_output">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(Commands and their output are to be printed here)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/hironx_ros_bridge/resource/hironx_commandpanel_main.ui
+++ b/hironx_ros_bridge/resource/hironx_commandpanel_main.ui
@@ -215,7 +215,7 @@
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Order of degree in the returned values in the result. Default: 4 &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="text">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Order degree&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Precision&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
             </widget>
            </item>

--- a/hironx_ros_bridge/resource/hironx_commandpanel_main.ui
+++ b/hironx_ros_bridge/resource/hironx_commandpanel_main.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>557</width>
-    <height>284</height>
+    <height>255</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <item row="0" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="5,5">
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,1,1,1,1">
+      <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,1">
        <property name="spacing">
         <number>6</number>
        </property>
@@ -41,8 +41,8 @@
         </widget>
        </item>
        <item>
-        <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0" columnstretch="7,0,3">
-         <item row="2" column="0">
+        <layout class="QGridLayout" name="gridLayout_2" rowstretch="0" columnstretch="7,3">
+         <item row="0" column="0">
           <layout class="QVBoxLayout" name="verticalLayout_4">
            <item>
             <widget class="QPushButton" name="pushButton_goInitial">
@@ -76,7 +76,7 @@
            </item>
           </layout>
          </item>
-         <item row="2" column="2">
+         <item row="0" column="1">
           <layout class="QVBoxLayout" name="verticalLayout_5">
            <item>
             <widget class="QLabel" name="label_duration">
@@ -113,44 +113,50 @@
         </layout>
        </item>
        <item>
-        <widget class="QPushButton" name="pushButton_servoOn">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;servoOn&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Servos on</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="pushButton_servoOff">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;servoOff&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Servos off</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="pushButton_startImpedance">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;startImpedance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Impedance start</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="pushButton_stopImpedance">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;stopImpedance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Impedance stop</string>
-         </property>
-        </widget>
+        <layout class="QGridLayout" name="gridLayout_impedance" rowstretch="0" columnstretch="6,4">
+         <item row="0" column="0">
+          <layout class="QVBoxLayout" name="verticalLayout_3">
+           <item>
+            <widget class="QPushButton" name="pushButton_startImpedance">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;startImpedance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>Impedance start</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pushButton_stopImpedance">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;stopImpedance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>Impedance stop</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="0" column="1">
+          <layout class="QVBoxLayout" name="verticalLayout_6">
+           <item>
+            <widget class="QRadioButton" name="radioButton_impedance_left">
+             <property name="text">
+              <string>Left arm</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="radioButton_impedance_right">
+             <property name="text">
+              <string>Right arm</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
        </item>
       </layout>
      </item>

--- a/hironx_ros_bridge/src/hironx_ros_bridge/command_widget.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/command_widget.py
@@ -93,6 +93,9 @@ class HironxoCommandPanel(QWidget):
         self.spinBox_precision_output.valueChanged[int].connect(self._get_precision_output)
         self.pushButton_groups.clicked[bool].connect(self._show_groups)
 
+    def _print_command(self, command_str):
+        self.textBrowser_output.append('***Command used***\n\t' + command_str)
+
     def _get_duration(self):
         '''
         @rtype float
@@ -115,16 +118,20 @@ class HironxoCommandPanel(QWidget):
         return checked_arm
 
     def _check_encoders(self):
+        self._print_command('checkEncoders()')
         self._rtm.checkEncoders()
 
     def _go_initial(self):
+        self._print_command('goInitial(tm={})'.format(self._get_duration()))
         self._rtm.goInitial(tm=self._get_duration())
 
     def _go_initial_factoryval(self):
+        self._print_command('goInitial(init_pose_type=1, tm={})'.format(self._get_duration()))
         self._rtm.goInitial(init_pose_type=self._rtm.INITPOS_TYPE_FACTORY,
                             tm=self._get_duration())
 
     def _go_offPose(self):
+        self._print_command('goOffPose(tm={})'.format(self._get_duration()))
         self._rtm.goOffPose(tm=self._get_duration())
 
     def _impedance_on_off(self, do_on=True):
@@ -140,8 +147,10 @@ class HironxoCommandPanel(QWidget):
         if not armgroup:
             raise AttributeError('No arm is specified for impedance control to start.')
         if do_on:
+            self._print_command('startImpedance({})'.format(armgroup))
             self._rtm.startImpedance(armgroup)
         elif not do_on:
+            self._print_command('stopImpedance({})'.format(armgroup))
             self._rtm.stopImpedance(armgroup)
 
     def _impedance_on(self):
@@ -179,10 +188,14 @@ class HironxoCommandPanel(QWidget):
             i += 1
 
     def _actual_pose_l(self):
-        self._show_actual_pose(self._rtm.getCurrentPose('LARM_JOINT5'))
+        target_joint = 'LARM_JOINT5'
+        self._print_command('getCurrentPose({})'.format(target_joint))
+        self._show_actual_pose(self._rtm.getCurrentPose(target_joint))
 
     def _actual_pose_r(self):
-        self._show_actual_pose(self._rtm.getCurrentPose('RARM_JOINT5'))
+        target_joint = 'LARM_JOINT5'
+        self._print_command('getCurrentPose({})'.format(target_joint))
+        self._show_actual_pose(self._rtm.getCurrentPose(target_joint))
 
     def _show_groups(self):
         groups = self._rtm.Groups
@@ -192,4 +205,5 @@ class HironxoCommandPanel(QWidget):
             str_elems = ''.join(str('\t' + e + '\n') for e in g[1])
             text += str_elems
 
+        self._print_command('Groups')
         self.textBrowser_output.append(text)

--- a/hironx_ros_bridge/src/hironx_ros_bridge/command_widget.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/command_widget.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2015, Tokyo Opensource Robotics Kyokai Association
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Tokyo Opensource Robotics Kyokai Association (TORK).
+#    nor the names of its contributors may be used to endorse or promote
+#    products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+
+from hironx_ros_bridge.hironx_client import HIRONX
+from hrpsys_ros_bridge.hrpsys_dashboard import HrpsysDashboard
+from python_qt_binding import loadUi
+from python_qt_binding.QtCore import Qt, Signal
+from python_qt_binding.QtGui import (QHeaderView, QItemSelectionModel,
+                                     QWidget)
+from rospkg import RosPack
+import rospy
+from rospy.exceptions import ROSException
+import rosservice
+from rqt_robot_dashboard.widgets import MenuDashWidget
+
+PKG_NAME = 'hironx_ros_bridge'
+
+
+class HironxoCommandPanel(QWidget):
+
+    def __init__(self, parent, guicontext):
+        '''
+        A GUi panel to list common operation commands for Hironx / NEXTAGE Open robot.
+
+        @param guicontext: The plugin context to create the monitor in.
+        @type guicontext: qt_gui.plugin_context.PluginContext
+        '''
+        super(HironxoCommandPanel, self).__init__()
+        self._parent = parent
+        self._guicontext = guicontext
+
+        # RTM Client
+        self._rtm = HIRONX()
+        self._rtm.init(robotname='HiroNX(Robot)0', url='')
+
+        rospack = RosPack()
+        ui_file = os.path.join(rospack.get_path(PKG_NAME), 'resource',
+                               'hironx_commandpanel_main.ui')
+        loadUi(ui_file, self, {'HironxoCommandPanel': HironxoCommandPanel})
+
+        # Assign callback methods
+        self.pushButton_checkEncoders.clicked[bool].connect(self._check_encoders)
+        self.pushButton_goInitial.clicked[bool].connect(self._go_initial)
+        self.pushButton_goInitial.clicked[bool].connect(self._go_initial)
+        self.pushButton_goInitial_factoryval.clicked[bool].connect(self._go_initial_factoryval)
+        self.pushButton_goOffPose.clicked[bool].connect(self._go_offPose)
+        self.pushButton_servoOn.clicked[bool].connect(self._servo_on)
+
+    def _get_duration(self):
+        '''
+        @rtype float
+        '''
+        return float(self.doubleSpinBox_duration.text())
+
+    def _check_encoders(self):
+        self._rtm.checkEncoders()
+
+    def _go_initial(self):
+        self._rtm.goInitial(tm=self._get_duration())
+
+    def _go_initial_factoryval(self):
+        self._rtm.goInitial(init_pose_type=self._rtm.INITPOS_TYPE_FACTORY,
+                            tm=self._get_duration())
+
+    def _go_offPose(self):
+        self._rtm.goOffPose(tm=self._get_duration())
+
+    def _servo_on(self):
+        self._rtm.servoOn()
+
+    def _servo_off(self):
+        self._rtm.servoOff()
+
+    def _impedance_on(self):
+        self._rtm.startImpedance()
+
+    def _imdedance_off(self):
+        self._rtm.stopImpedance()

--- a/hironx_ros_bridge/src/hironx_ros_bridge/command_widget.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/command_widget.py
@@ -83,7 +83,6 @@ class HironxoCommandPanel(QWidget):
         # Assign callback methods
         self.pushButton_checkEncoders.clicked[bool].connect(self._check_encoders)
         self.pushButton_goInitial.clicked[bool].connect(self._go_initial)
-        self.pushButton_goInitial.clicked[bool].connect(self._go_initial)
         self.pushButton_goInitial_factoryval.clicked[bool].connect(self._go_initial_factoryval)
         self.pushButton_goOffPose.clicked[bool].connect(self._go_offPose)
         self.pushButton_startImpedance.clicked[bool].connect(self._impedance_on)

--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
@@ -140,6 +140,10 @@ class HIRONX(HrpsysConfigurator):
 
     hrpsys_version = '0.0.0'
 
+    _MSG_IMPEDANCE_CALL_DONE = (" call is done. This does't necessarily mean " +
+                               "the function call was successful, since not " +
+                               "all methods internally called return status")
+
     def init(self, robotname="HiroNX(Robot)0", url=""):
         '''
         Calls init from its superclass, which tries to connect RTCManager,
@@ -820,6 +824,7 @@ class HIRONX(HrpsysConfigurator):
             self.startImpedance_315_2(arm, **kwargs)
         else:
             self.startImpedance_315_3(arm, **kwargs)
+        print('startImpedance {}'.format(self._MSG_IMPEDANCE_CALL_DONE))
 
     def stopImpedance(self, arm):
         if self.hrpsys_version < '315.2.0':
@@ -828,6 +833,7 @@ class HIRONX(HrpsysConfigurator):
             self.stopImpedance_315_2(arm)
         else:
             self.stopImpedance_315_3(arm)
+        print('stopImpedance {}'.format(self._MSG_IMPEDANCE_CALL_DONE))
 
     def removeForceSensorOffset(self):
         self.rh_svc.removeForceSensorOffset()

--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_dashboard.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_dashboard.py
@@ -1,17 +1,52 @@
 #!/usr/bin/env python
 
-from hrpsys_ros_bridge.hrpsys_dashboard import HrpsysDashboard
-from rqt_robot_dashboard.widgets import MenuDashWidget
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2015, JSK Lab, University of Tokyo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of JSK Lab, University of Tokyo. nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
 
 from python_qt_binding.QtGui import QMessageBox, QLabel, QPalette
 
-import os
+from hrpsys_ros_bridge.hrpsys_dashboard import HrpsysDashboard
+from rqt_robot_dashboard.widgets import MenuDashWidget
+
+
 class HiroNXNameLabel(QLabel):
     def __init__(self, name):
-       super(HiroNXNameLabel, self).__init__()
-       palette = QPalette()
-       self.setStyleSheet('font-size: larger; font-weight: bold; color: #ffffff; background-color: darkgreen;')
-       self.setText(name)
+        super(HiroNXNameLabel, self).__init__()
+        palette = QPalette()
+        self.setStyleSheet('font-size: larger; font-weight: bold; color: #ffffff; background-color: darkgreen;')
+        self.setText(name)
+
 
 class HiroNXDashboard(HrpsysDashboard):
     def setup(self, context):
@@ -19,7 +54,7 @@ class HiroNXDashboard(HrpsysDashboard):
         self.name = "HiroNX dashboard"
         self._imp_button = None
         self._pose_button = None
-        self._name_label = HiroNXNameLabel("HiroNX "+os.environ["ROS_MASTER_URI"]+" ")
+        self._name_label = HiroNXNameLabel("HiroNX " + os.environ["ROS_MASTER_URI"] + " ")
 
     def get_widgets(self):
         widgets = super(HiroNXDashboard, self).get_widgets()

--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_dashboard.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_dashboard.py
@@ -39,6 +39,8 @@ from python_qt_binding.QtGui import QMessageBox, QLabel, QPalette
 from hrpsys_ros_bridge.hrpsys_dashboard import HrpsysDashboard
 from rqt_robot_dashboard.widgets import MenuDashWidget
 
+from hironx_ros_bridge.command_widget import HironxoCommandPanel
+
 
 class HiroNXNameLabel(QLabel):
     def __init__(self, name):
@@ -55,6 +57,8 @@ class HiroNXDashboard(HrpsysDashboard):
         self._imp_button = None
         self._pose_button = None
         self._name_label = HiroNXNameLabel("HiroNX " + os.environ["ROS_MASTER_URI"] + " ")
+        self._command_panel = HironxoCommandPanel(self, self.context)
+        context.add_widget(self._command_panel)
 
     def get_widgets(self):
         widgets = super(HiroNXDashboard, self).get_widgets()


### PR DESCRIPTION
Adding GUI access for RTM commands.

![rqt_dashboard_hironx_command_20151223](https://cloud.githubusercontent.com/assets/1840401/11993697/04f485c0-a9e9-11e5-9a07-afd90245644d.png)

Todos:
- [x] Implement right-hand side buttons
- [x] Show corresponding command in the textarea
- [x] <s>Show errors in the textarea</s> --> almost all methods don't return errors. This needs addressed in another PRs.
- [x] <s>Add ROS commands?</s> --> delegated to upstream.
- [ ] Add unit test (example https://github.com/jsk-ros-pkg/jsk_common/pull/1291)
