### PR TITLE
ROS_Client.py inherits moveit_commander.RobotCommander

### DIFF
--- a/hironx_moveit_config/CMakeLists.txt
+++ b/hironx_moveit_config/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(hironx_moveit_config)
 
-find_package(catkin REQUIRED COMPONENTS hironx_ros_bridge)
+find_package(catkin REQUIRED COMPONENTS hironx_ros_bridge rostest)
 
 # generate model file
 file(MAKE_DIRECTORY "models/meshes")
@@ -18,3 +18,5 @@ catkin_package()
 install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION} PATTERN ".svn" EXCLUDE)
 install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION} PATTERN ".svn" EXCLUDE)
 install(DIRECTORY models DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION} PATTERN ".svn" EXCLUDE)
+
+add_rostest(test/test-hironx-moveit.test)

--- a/hironx_moveit_config/package.xml
+++ b/hironx_moveit_config/package.xml
@@ -27,4 +27,6 @@
   <run_depend>moveit_planners</run_depend>
   <run_depend>moveit_ros</run_depend>
   <run_depend>pr2_moveit_plugins</run_depend>
+  
+  <test_depend>rostest</test_depend>
 </package>

--- a/hironx_moveit_config/test/test_hironx_moveit.py
+++ b/hironx_moveit_config/test/test_hironx_moveit.py
@@ -44,6 +44,8 @@ from geometry_msgs.msg import Pose, PoseStamped
 from moveit_commander import MoveGroupCommander
 import rospy
 
+from hironx_ros_bridge.ros_client import ROS_Client
+
 _PKG = 'hironx_ros_bridge'
 _SEC_WAIT_BETWEEN_TESTCASES = 3
 
@@ -185,6 +187,21 @@ class TestHironxMoveit(unittest.TestCase):
 #    def test_simple_unittest(self):
 #        self.assertEqual(1, 1)
 
+    def test_rosclient_robotcommander(self):
+        '''
+        Starting from https://github.com/start-jsk/rtmros_hironx/pull/422,
+        ROS_Client.py depends on moveit_commander.RobotCommander class.
+        This case tests the integration of ROS_Client.py and RobotCommander.
+
+        Developers need to avoid testing moveit_commander.RobotCommander itself
+        -- that needs to be done upstream.
+        '''
+        rosclient = ROS_Client()
+
+        # If the list of movegroups are not none, that can mean
+        # RobotCommander is working as expected.
+        groupnames = rosclient.get_group_names()
+        self.assertIsNotNone(groupnames)
 
 if __name__ == '__main__':
     import rostest

--- a/hironx_moveit_config/test/test_hironx_moveit.py
+++ b/hironx_moveit_config/test/test_hironx_moveit.py
@@ -2,7 +2,7 @@
 
 # Software License Agreement (BSD License)
 #
-# Copyright (c) 2015, Tokyo Opensource Robotics Kyokai Association 
+# Copyright (c) 2015, Tokyo Opensource Robotics Kyokai Association
 # (TORK) All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -38,15 +38,15 @@
 # structure.
 
 import numpy
-import time
 import unittest
 
 from geometry_msgs.msg import Pose, PoseStamped
-from moveit_commander import MoveGroupCommander, conversions
+from moveit_commander import MoveGroupCommander
 import rospy
 
 _PKG = 'hironx_ros_bridge'
 _SEC_WAIT_BETWEEN_TESTCASES = 3
+
 
 class TestHironxMoveit(unittest.TestCase):
 
@@ -79,19 +79,24 @@ class TestHironxMoveit(unittest.TestCase):
         self.larm_current_pose = self.larm.get_current_pose().pose
         # For botharms get_current_pose ends with no eef error.
 
-        self.init_rtm_jointvals = [0.010471975511965976, 0.0, -1.7453292519943295, -0.26529004630313807, 0.16406094968746698, -0.05585053606381855, -0.010471975511965976, 0.0, -1.7453292519943295, 0.26529004630313807, 0.16406094968746698, 0.05585053606381855]
+        self.init_rtm_jointvals = [0.010471975511965976, 0.0, -1.7453292519943295, -0.26529004630313807,
+                                   0.16406094968746698, -0.05585053606381855, -0.010471975511965976, 0.0,
+                                   -1.7453292519943295, 0.26529004630313807, 0.16406094968746698, 0.05585053606381855]
 
         # These represent a pose as in the image https://goo.gl/hYa15h
-        self.banzai_pose_larm_goal = [-0.0280391167993, 0.558512828409, 0.584801820449, 0.468552399035, -0.546097642377, -0.449475560632, 0.529346516701]
-        self.banzai_pose_rarm_goal = [0.0765219167208, -0.527210000725, 0.638387081642, -0.185009037721, -0.683111796219, 0.184872589841, 0.681873929223]
-        self.banzai_jointvals_goal = [1.3591412928962834, -1.5269810342586994, -1.5263864987632225, -0.212938998306429, -0.19093239258017988, -1.5171864827145887,
-                                      -0.7066724299606867, -1.9314110634425135, -1.4268663042616962, 1.0613942164863952, 0.9037643195141568, 1.835342100423069]
+        self.banzai_pose_larm_goal = [-0.0280391167993, 0.558512828409, 0.584801820449,
+                                      0.468552399035, -0.546097642377, -0.449475560632, 0.529346516701]
+        self.banzai_pose_rarm_goal = [0.0765219167208, -0.527210000725, 0.638387081642,
+                                      -0.185009037721, -0.683111796219, 0.184872589841, 0.681873929223]
+        self.banzai_jointvals_goal = [1.3591412928962834, -1.5269810342586994, -1.5263864987632225, -0.212938998306429,
+                                      -0.19093239258017988, -1.5171864827145887, -0.7066724299606867, -1.9314110634425135,
+                                      -1.4268663042616962, 1.0613942164863952, 0.9037643195141568, 1.835342100423069]
 
     def _set_target_random(self):
         '''
         @type self: moveit_commander.MoveGroupCommander
-        @param self: In this particular test script, the argument "self" is either
-                     'rarm' or 'larm'.
+        @param self: In this particular test script, the argument "self" is
+                     either 'rarm' or 'larm'.
         '''
         global current, current2, target
         current = self.get_current_pose()
@@ -107,8 +112,8 @@ class TestHironxMoveit(unittest.TestCase):
     # the method on interpreter.
     # Although not sure if this is the smartest Python code, this works fine from
     # Python interpreter.
-    ##MoveGroupCommander._set_target_random = _set_target_random
-    
+    # #MoveGroupCommander._set_target_random = _set_target_random
+
     # ****** Usage ******
     #
     # See wiki tutorial
@@ -116,7 +121,7 @@ class TestHironxMoveit(unittest.TestCase):
 
     def test_set_pose_target_rpy(self):
         # #rpy ver
-        target = [0.2035, -0.5399, 0.0709, 0,-1.6,0]
+        target = [0.2035, -0.5399, 0.0709, 0, -1.6, 0]
         self.rarm.set_pose_target(target)
         self.rarm.plan()
         self.assertTrue(self.rarm.go())
@@ -133,8 +138,9 @@ class TestHironxMoveit(unittest.TestCase):
 
     def test_botharms_get_joint_values(self):
         '''
-        "both_arm" move group can't set pose target for now (July, 2015) due to 
-        missing eef in the moveit config. Here checking if MoveGroup.get_joint_values is working.
+        "both_arm" move group can't set pose target for now (July, 2015) due to
+        missing eef in the moveit config. Here checking if
+        MoveGroup.get_joint_values is working.
         '''
 
         self.larm.set_pose_target(self.banzai_pose_larm_goal)
@@ -144,17 +150,19 @@ class TestHironxMoveit(unittest.TestCase):
         self.rarm.plan()
         self.rarm.go()
         # Comparing to the 3rd degree seems too aggressive; example output:
-        #   x: array([ 1.35906843, -1.52695742, -1.52658066, -0.21309358, -0.19092542,
-        #             -1.51707957, -0.70651268, -1.93170852, -1.42660669,  1.0629058 ,
-        #              0.90412021,  1.83650476])
-        #   y: array([ 1.35914129, -1.52698103, -1.5263865 , -0.212939  , -0.19093239,
-        #             -1.51718648, -0.70667243, -1.93141106, -1.4268663 ,  1.06139422,
-        #              0.90376432,  1.8353421 ])
-        numpy.testing.assert_almost_equal(self.botharms.get_current_joint_values(), self.banzai_jointvals_goal, 2)
+        #   x: array([ 1.35906843, -1.52695742, -1.52658066, -0.21309358,
+        #              -0.19092542, -1.51707957, -0.70651268, -1.93170852,
+        #              -1.42660669,  1.0629058, 0.90412021,  1.83650476])
+        #   y: array([ 1.35914129, -1.52698103, -1.5263865 , -0.212939,
+        #              -0.19093239, -1.51718648, -0.70667243, -1.93141106,
+        #              -1.4268663 ,  1.06139422, 0.90376432,  1.8353421 ])
+        numpy.testing.assert_almost_equal(self.botharms.get_current_joint_values(),
+                                          self.banzai_jointvals_goal, 2)
 
     def test_botharms_set_named_target(self):
         '''
-        Test if moveit_commander.set_named_target brings the arms to the init_rtm pose defined in HiroNx.srdf.
+        Test if moveit_commander.set_named_target brings the arms to
+        the init_rtm pose defined in HiroNx.srdf.
         '''
         # Move the arms to non init pose.
         self.larm.set_pose_target(self.banzai_pose_larm_goal)
@@ -168,9 +176,11 @@ class TestHironxMoveit(unittest.TestCase):
         self.botharms.plan()
         self.botharms.go()
 
-        # Raises AssertException when the assertion fails, which automatically be flagged false by unittest framework.
+        # Raises AssertException when the assertion fails, which
+        # automatically be flagged false by unittest framework.
         # http://stackoverflow.com/a/4319836/577001
-        numpy.testing.assert_almost_equal(self.botharms.get_current_joint_values(), self.init_rtm_jointvals, 3)
+        numpy.testing.assert_almost_equal(self.botharms.get_current_joint_values(),
+                                          self.init_rtm_jointvals, 3)
 
 #    def test_simple_unittest(self):
 #        self.assertEqual(1, 1)

--- a/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py
@@ -36,8 +36,7 @@ import copy
 import math
 
 import actionlib
-from moveit_commander import MoveGroupCommander
-from moveit_commander import MoveItCommanderException
+from moveit_commander import MoveGroupCommander, MoveItCommanderException, RobotCommander
 import rospy
 from pr2_controllers_msgs.msg import JointTrajectoryAction
 from pr2_controllers_msgs.msg import JointTrajectoryGoal
@@ -53,13 +52,14 @@ _MSG_ASK_ISSUEREPORT = 'Your report to ' + \
                        'about the issue you are seeing is appreciated.'
 
 
-class ROS_Client(object):
+class ROS_Client(RobotCommander):
     '''
-    This class:
-
-    - holds methods that are specific to Kawada Industries' dual-arm
+    This class holds methods that are specific to Kawada Industries' dual-arm
     robot called Hiro, via ROS.
-    - As of July 2014, this class is only intended to be used through HIRONX
+
+    @since: December 2014: Now this class is replacing the default programming interface
+            with HIRONX (hironx_client.py).
+    @since: July 2014: this class is only intended to be used through HIRONX
       class.
     '''
 
@@ -71,6 +71,8 @@ class ROS_Client(object):
         '''
         @type jointgroups: [str]
         '''
+        super(ROS_Client, self).__init__()  # This solves https://github.com/start-jsk/rtmros_hironx/issues/300
+
         # if we do not have ros running, return 
         try:
             rospy.get_master().getSystemState()
@@ -97,12 +99,17 @@ class ROS_Client(object):
         except RuntimeError as e:
             rospy.logerr(str(e) + self._MSG_NO_MOVEGROUP_FOUND)
 
+#    def __getattr__(self, name):
+#        '''
+#        Trying to resolve https://github.com/start-jsk/rtmros_hironx/issues/300
+#        '''
+#        return object.__getattr__(self, name)
+
     def _init_moveit_commanders(self):
         '''
         @raise RuntimeError: When MoveGroup is not running.
         '''
         # left_arm, right_arm are fixed in nextage_moveit_config pkg.
-
         try:
             self._movegr_larm = MoveGroupCommander(Constant.GRNAME_LEFT_ARM_MOVEGROUP)
             self._movegr_rarm = MoveGroupCommander(Constant.GRNAME_RIGHT_ARM_MOVEGROUP)


### PR DESCRIPTION
With this, users can use MoveIt! and HiroNXO specific methods through the same interface.

```
$ ipython -i `rospack find hironx_ros_bridge`/scripts/hironx.py
:
[hrpsys.py] initialized successfully
[ INFO] [1453342567.509114100, 23.604999999]: Loading robot model 'HiroNX'...
[INFO] [WallTime: 1453342568.288001] [24.385000] Joint names; Torso: ['CHEST_JOINT0']
    Head: ['HEAD_JOINT0', 'HEAD_JOINT1']
    L-Arm: ['LARM_JOINT0', 'LARM_JOINT1', 'LARM_JOINT2', 'LARM_JOINT3', 'LARM_JOINT4', 'LARM_JOINT5']
    R-Arm: ['RARM_JOINT0', 'RARM_JOINT1', 'RARM_JOINT2', 'RARM_JOINT3', 'RARM_JOINT4', 'RARM_JOINT5']
[ INFO] [1453342569.088206911, 25.194999999]: Ready to take MoveGroup commands for group left_arm.
[ INFO] [1453342569.674976487, 25.779999999]: Ready to take MoveGroup commands for group right_arm.

In [1]: ros.
ros.Joint                        ros.get_group_names              ros.get_root_link
ros.Link                         ros.get_joint                    ros.go_init
ros.get_current_state            ros.get_joint_names              ros.has_group
ros.get_current_variable_values  ros.get_link                     ros.set_joint_angles_deg
ros.get_default_owner_group      ros.get_link_names               ros.set_joint_angles_rad
ros.get_group                    ros.get_planning_frame           ros.set_pose

In [1]: ros.get_current_state()
Out[1]: 
joint_state: 
  header: 
    seq: 0
    stamp: 
      secs: 0
      nsecs: 0
    frame_id: /WAIST
  name: ['CHEST_JOINT0', 'HEAD_JOINT0', 'HEAD_JOINT1', 'LARM_JOINT0', 'LARM_JOINT1', 'LARM_JOINT2', 'LARM_JOINT3', 'LARM_JOINT4', 'LARM_JOINT5', 'LHAND_JOINT0', 'LHAND_JOINT1', 'LHAND_JOINT2', 'LHAND_JOINT3', 'RARM_JOINT0', 'RARM_JOINT1', 'RARM_JOINT2', 'RARM_JOINT3', 'RARM_JOINT4', 'RARM_JOINT5', 'RHAND_JOINT0', 'RHAND_JOINT1', 'RHAND_JOINT2', 'RHAND_JOINT3']
  position: [0.0, 0.0, 0.0, 0.010472, 0.0, -1.74533, -0.26529, 0.164061, -0.055851, 0.0, 0.0, 0.0, 0.0, -0.010472, 0.0, -1.74533, 0.26529, 0.164061, 0.055851, 0.0, 0.0, 0.0, 0.0]
  velocity: []
  effort: []
multi_dof_joint_state: 
  header: 
    seq: 0
    stamp: 
      secs: 0
      nsecs: 0
    frame_id: /WAIST
  joint_names: []
  transforms: []
  twist: []
  wrench: []
attached_collision_objects: []
is_diff: False

In [2]: ros.get_group()
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-0c2c88c4273c> in <module>()
----> 1 ros.get_group()

TypeError: get_group() takes exactly 2 arguments (1 given)

In [3]: ros.get_group_names()
Out[3]: ['both_arm', 'left_arm', 'left_gripper', 'right_arm', 'right_gripper']

In [4]: ros.get_joint_names()
Out[4]: 
['virtual_joint',
 'CHEST_JOINT0',
 'HEAD_JOINT0',
 'HEAD_JOINT1',
 'LARM_JOINT0',
 'LARM_JOINT1',
 'LARM_JOINT2',
 'LARM_JOINT3',
 'LARM_JOINT4',
 'LARM_JOINT5',
 'LHAND_JOINT0',
 'LHAND_JOINT1',
 'LHAND_JOINT2',
 'LHAND_JOINT3',
 'RARM_JOINT0',
 'RARM_JOINT1',
 'RARM_JOINT2',
 'RARM_JOINT3',
 'RARM_JOINT4',
 'RARM_JOINT5',
 'RHAND_JOINT0',
 'RHAND_JOINT1',
 'RHAND_JOINT2',
 'RHAND_JOINT3']

In [5]: ros.get_link_names()
Out[5]: 
['WAIST',
 'CHEST_JOINT0_Link',
 'HEAD_JOINT0_Link',
 'HEAD_JOINT1_Link',
 'LARM_JOINT0_Link',
 'LARM_JOINT1_Link',
 'LARM_JOINT2_Link',
 'LARM_JOINT3_Link',
 'LARM_JOINT4_Link',
 'LARM_JOINT5_Link',
 'LHAND_JOINT0_Link',
 'LHAND_JOINT1_Link',
 'LHAND_JOINT2_Link',
 'LHAND_JOINT3_Link',
 'RARM_JOINT0_Link',
 'RARM_JOINT1_Link',
 'RARM_JOINT2_Link',
 'RARM_JOINT3_Link',
 'RARM_JOINT4_Link',
 'RARM_JOINT5_Link',
 'RHAND_JOINT0_Link',
 'RHAND_JOINT1_Link',
 'RHAND_JOINT2_Link',
 'RHAND_JOINT3_Link']

In [6]: ros.get_root_link()
Out[6]: 'WAIST'

In [9]: mg_both_arms = ros.get_group('both_arm')
[ INFO] [1453342663.169166890, 119.384999999]: Ready to take MoveGroup commands for group both_arm.

In [10]: mg_both_arms.
mg_both_arms.allow_looking                     mg_both_arms.go
mg_both_arms.allow_replanning                  mg_both_arms.has_end_effector_link
mg_both_arms.attach_object                     mg_both_arms.pick
mg_both_arms.clear_path_constraints            mg_both_arms.place
mg_both_arms.clear_pose_target                 mg_both_arms.plan
mg_both_arms.clear_pose_targets                mg_both_arms.remember_joint_values
mg_both_arms.compute_cartesian_path            mg_both_arms.set_constraints_database
mg_both_arms.detach_object                     mg_both_arms.set_end_effector_link
mg_both_arms.execute                           mg_both_arms.set_goal_joint_tolerance
mg_both_arms.forget_joint_values               mg_both_arms.set_goal_orientation_tolerance
mg_both_arms.get_active_joints                 mg_both_arms.set_goal_position_tolerance
mg_both_arms.get_current_joint_values          mg_both_arms.set_goal_tolerance
mg_both_arms.get_current_pose                  mg_both_arms.set_joint_value_target
mg_both_arms.get_current_rpy                   mg_both_arms.set_named_target
mg_both_arms.get_end_effector_link             mg_both_arms.set_orientation_target
mg_both_arms.get_goal_joint_tolerance          mg_both_arms.set_path_constraints
mg_both_arms.get_goal_orientation_tolerance    mg_both_arms.set_planner_id
mg_both_arms.get_goal_position_tolerance       mg_both_arms.set_planning_time
mg_both_arms.get_goal_tolerance                mg_both_arms.set_pose_reference_frame
mg_both_arms.get_joints                        mg_both_arms.set_pose_target
mg_both_arms.get_known_constraints             mg_both_arms.set_pose_targets
mg_both_arms.get_name                          mg_both_arms.set_position_target
mg_both_arms.get_path_constraints              mg_both_arms.set_random_target
mg_both_arms.get_planning_frame                mg_both_arms.set_rpy_target
mg_both_arms.get_planning_time                 mg_both_arms.set_start_state
mg_both_arms.get_pose_reference_frame          mg_both_arms.set_start_state_to_current_state
mg_both_arms.get_random_joint_values           mg_both_arms.set_support_surface_name
mg_both_arms.get_random_pose                   mg_both_arms.set_workspace
mg_both_arms.get_remembered_joint_values       mg_both_arms.shift_pose_target
mg_both_arms.get_variable_count                mg_both_arms.stop

In [10]: mg_both_arms.set_pose_target?
Type:       instancemethod
String Form:<bound method MoveGroupCommander.set_pose_target of <moveit_commander.move_group.MoveGroupCommander object at 0x7f9016441510>>
File:       /opt/ros/indigo/lib/python2.7/dist-packages/moveit_commander/move_group.py
Definition: mg_both_arms.set_pose_target(self, pose, end_effector_link='')
Docstring:  Set the pose of the end-effector, if one is available. The expected input is a Pose message, a PoseStamped message or a list of 6 floats:
```
