### PR TITLE
[HIRONX] Fix https://github.com/tork-a/rtmros_nextage/issues/227

### DIFF
--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
@@ -673,7 +673,7 @@ class HIRONX(HrpsysConfigurator):
 
         is_result_hw = True
         print self.configurator_name, 'calib-joint ' + jname + ' ' + option
-        is_result_hw = is_result_hw and self.rh_svc.initializeJointAngle(jname, option)
+        self.rh_svc.initializeJointAngle(jname, option)
         print self.configurator_name, 'done'
         is_result_hw = is_result_hw and self.rh_svc.power('all', SWITCH_OFF)
         self.goActual()  # This needs to happen before turning servo on.


### PR DESCRIPTION
`rh_svc.initializeJointAngle` returns `void`, not `bool` (see [this conversation](https://github.com/start-jsk/rtmros_hironx/pull/418/files#r51684277)).

@emijah Please review.
