### PR TITLE
[ROS py client] Fix #430

### DIFF
--- a/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py
@@ -71,14 +71,14 @@ class ROS_Client(RobotCommander):
         '''
         @param jointgroups [str]: Deprecated. No need after version 1.1.4 onward.
         '''
-        super(ROS_Client, self).__init__()  # This solves https://github.com/start-jsk/rtmros_hironx/issues/300
-
         # if we do not have ros running, return 
         try:
             rospy.get_master().getSystemState()
         except Exception:
             print('[ros_client] ros master is not running, so do not create ros client...')
             return
+
+        super(ROS_Client, self).__init__()  # This solves https://github.com/start-jsk/rtmros_hironx/issues/300
 
         rospy.init_node('hironx_ros_client')
 

--- a/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py
@@ -75,7 +75,8 @@ class ROS_Client(RobotCommander):
         try:
             rospy.get_master().getSystemState()
         except Exception:
-            print('[ros_client] ros master is not running, so do not create ros client...')
+            from termcolor import colored
+            print(colored('[ERROR][ros_client] ros master is not running, so do not create ros client...', 'red'))
             return
 
         super(ROS_Client, self).__init__()  # This solves https://github.com/start-jsk/rtmros_hironx/issues/300


### PR DESCRIPTION
Turned out that it was `moveit_commander.RobotCommander` that keeps waiting for the ros master.

Given that we want to use `rostest` that starts ros master, I don't know how to write a test for this feature. Asked [a question](http://answers.ros.org/question/225898/tests-if-ros-master-is-not-running-using-rostest/).
