### PR TITLE
[ROS_Client] Correctly import termcolor. Better error handling (Fix #436)

### DIFF
--- a/hironx_ros_bridge/CMakeLists.txt
+++ b/hironx_ros_bridge/CMakeLists.txt
@@ -104,5 +104,9 @@ add_rostest(test/test-hironx-ros-bridge-send.test)
 add_rostest(test/test-hironx-ros-bridge-pose.test)
 add_rostest(test/test-hironx-ros-bridge-controller.test)
 
+if (CATKIN_ENABLE_TESTING)
+  catkin_add_nosetests(test/test_no_ros.py)
+endif()
+
 roslint_python(scripts/hironx.py src/hironx_ros_bridge/hironx_client.py src/hironx_ros_bridge/ros_client.py src/hironx_ros_bridge/constant.py)
 roslint_cpp()

--- a/hironx_ros_bridge/package.xml
+++ b/hironx_ros_bridge/package.xml
@@ -34,11 +34,14 @@
   <run_depend>hrpsys_ros_bridge</run_depend>
   <run_depend>openni2_launch</run_depend>
   <run_depend>pr2_controllers_msgs</run_depend>
+  <run_depend>python-termcolor</run_depend>
   <run_depend>roslib</run_depend>
   <run_depend>rosbash</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>roslang</run_depend>
   <run_depend>tf</run_depend>
+
+  <test_depend>unittest</test_depend>
   
   <!-- <test_depend>hrpsys_ros_bridge</test_depend> -->
 

--- a/hironx_ros_bridge/scripts/hironx.py
+++ b/hironx_ros_bridge/scripts/hironx.py
@@ -33,6 +33,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import socket
+from termcolor import colored
 
 try:  # catkin does not requires load_manifest
     import hironx_ros_bridge
@@ -75,7 +77,10 @@ if __name__ == '__main__':
     robot.init(robotname=args.robot, url=args.modelfile)
 
     # ROS Client
-    ros = ROS_Client()
+    try:
+        ros = ROS_Client()
+    except socket.error as e:
+        print(colored(e.strerror, 'red'))
 
 # for simulated robot
 # $ ./hironx.py

--- a/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py
@@ -34,10 +34,12 @@
 
 import copy
 import math
+import socket
 
 import actionlib
 from moveit_commander import MoveGroupCommander, MoveItCommanderException, RobotCommander
 import rospy
+from rospy import ROSInitException
 from pr2_controllers_msgs.msg import JointTrajectoryAction
 from pr2_controllers_msgs.msg import JointTrajectoryGoal
 from geometry_msgs.msg import Pose
@@ -74,10 +76,13 @@ class ROS_Client(RobotCommander):
         # if we do not have ros running, return 
         try:
             rospy.get_master().getSystemState()
-        except Exception:
-            from termcolor import colored
-            print(colored('[ERROR][ros_client] ros master is not running, so do not create ros client...', 'red'))
-            return
+        except socket.error as e:
+            errormsg = '[ros_client] ros master is not running, so do not create ros client...'
+            raise ROSInitException(errormsg)
+        except Exception as e:
+            errormsg = '[ros_client] Unknown exception occurred, so do not create ros client...'
+            rospy.logerr(errormsg)
+            raise e
 
         super(ROS_Client, self).__init__()  # This solves https://github.com/start-jsk/rtmros_hironx/issues/300
 

--- a/hironx_ros_bridge/test/test-hironx-ros-bridge.test
+++ b/hironx_ros_bridge/test/test-hironx-ros-bridge.test
@@ -11,6 +11,7 @@
   <param name="joint_states_test/hz" value="200" />
   <param name="joint_states_test/hzerror" value="10" />
   <param name="joint_states_test/test_duration" value="5.0" />
+  <param name="joint_states_test/wait_time" value="60.0" /> <!-- as opposed to its default: 20.0 -->
 
   <test test-name="joint_states_test" pkg="rostest" type="hztest" name="joint_states_test" time-limit="100"/>
 

--- a/hironx_ros_bridge/test/test_no_ros.py
+++ b/hironx_ros_bridge/test/test_no_ros.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2016, Tokyo Opensource Robotics Kyokai Association (TORK)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Tokyo Opensource Robotics Kyokai Association. nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+PKG = 'hironx_ros_bridge'
+import unittest
+
+from hironx_ros_bridge.ros_client import ROS_Client
+from rospy import ROSInitException
+
+
+class TestNoRos(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        True
+
+    @classmethod
+    def tearDownClass(cls):
+        True
+
+    def test_noros(self):
+        '''
+        Test if the certain exception is returned when no ROS master is available.
+        '''
+        try:
+            rosclient = ROS_Client()
+        except ROSInitException as e:
+            self.assertRaises(ROSInitException)
+
+if __name__ == '__main__':
+    import rostest
+    rostest.rosrun(PKG, 'test_no_ros', TestNoRos)


### PR DESCRIPTION
`termcolor` is [available as a binary on multiple Ubuntu distros](https://github.com/ros/rosdistro/blob/99695ed25cd53ad0c113ed2f6efe0fb24fc98140/rosdep/python.yaml#L1885-L1923). 
In the previous code, it's just <s>my Python code was wrong</s> `python-termcolor` wasn't specified as a dependency so that it may not have been installed depending on machines.

Also added is a `nosetest` that checks if the exception is thrown when ros master is not running.
