### PR TITLE
[ros_bridge] test_depend on unittest seems (no longer) necessary

### DIFF
--- a/hironx_ros_bridge/package.xml
+++ b/hironx_ros_bridge/package.xml
@@ -41,10 +41,6 @@
   <run_depend>roslang</run_depend>
   <run_depend>tf</run_depend>
 
-  <test_depend>unittest</test_depend>
-  
-  <!-- <test_depend>hrpsys_ros_bridge</test_depend> -->
-
   <export>
     <rqt_gui plugin="${prefix}/rqt_plugin.xml"/>
   </export>


### PR DESCRIPTION
In Catkin's [hydro doc](http://docs.ros.org/hydro/api/catkin/html/howto/format2/python_nose_configuration.html) we need this dependency, but in [Indigo doc](http://docs.ros.org/indigo/api/catkin/html/howto/format2/python_nose_configuration.html) we no longer need it (bloom actually emits rosdep error).
