### PR TITLE
add test catch wrong exit of ros_client

### DIFF
--- a/hironx_ros_bridge/package.xml
+++ b/hironx_ros_bridge/package.xml
@@ -34,7 +34,6 @@
   <run_depend>hrpsys_ros_bridge</run_depend>
   <run_depend>openni2_launch</run_depend>
   <run_depend>pr2_controllers_msgs</run_depend>
-  <run_depend>python-termcolor</run_depend>
   <run_depend>roslib</run_depend>
   <run_depend>rosbash</run_depend>
   <run_depend>rospy</run_depend>

--- a/hironx_ros_bridge/scripts/hironx.py
+++ b/hironx_ros_bridge/scripts/hironx.py
@@ -34,7 +34,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import socket
-from termcolor import colored
 
 try:  # catkin does not requires load_manifest
     import hironx_ros_bridge
@@ -80,7 +79,7 @@ if __name__ == '__main__':
     try:
         ros = ROS_Client()
     except socket.error as e:
-        print(colored(e.strerror, 'red'))
+        print("\033[31m%s\033[0m" % (e.strerror))
 
 # for simulated robot
 # $ ./hironx.py

--- a/hironx_ros_bridge/test/test-hironx-ros-bridge.test
+++ b/hironx_ros_bridge/test/test-hironx-ros-bridge.test
@@ -15,4 +15,10 @@
 
   <test test-name="joint_states_test" pkg="rostest" type="hztest" name="joint_states_test" time-limit="100"/>
 
+  <test test-name="test_no_moveit" pkg="hironx_ros_bridge" type="test_no_moveit.py" name="test_no_moveit"
+        args="HiroNX(Robot)0
+              $(find hironx_ros_bridge)/models/kawada-hironx.dae
+              -ORBInitRef NameService=corbaloc:iiop:localhost:$(arg corbaport)/NameService"
+         time-limit="100" />
+
 </launch>

--- a/hironx_ros_bridge/test/test_no_moveit.py
+++ b/hironx_ros_bridge/test/test_no_moveit.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2016, Tokyo Opensource Robotics Kyokai Association (TORK)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Tokyo Opensource Robotics Kyokai Association. nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+PKG = 'hironx_ros_bridge'
+import unittest
+
+import sys, subprocess
+
+class TestNoMoveit(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        True
+
+    @classmethod
+    def tearDownClass(cls):
+        True
+
+    def test_nomoveit(self):
+        '''
+        Test if the certain exception is returned when no ROS master is available.
+        '''
+        try:
+            p = subprocess.Popen(["rosrun", "hironx_ros_bridge", "hironx.py", sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            out, err = p.communicate()
+            print(out)
+            print(err)
+            self.assertTrue(p.returncode==0, "[%s] ==> return code is not 0" % (err))
+        except Exception as e:
+            self.fail(str(e))
+
+if __name__ == '__main__':
+    import rostest
+    rostest.rosrun(PKG, 'test_no_moveit', TestNoMoveit)


### PR DESCRIPTION
This is super LOW PRIORITY:

I have noticed following starange messsage when launching `nextage_ros_bridge_simulation.py`

```
[WARN] [WallTime: 1455169354.314665] [4.955000] Moveit is not started yet, if you want to use MoveIt!
Make sure you've launched MoveGroup (e.g. by launching moveit_planning_execution.launch)
[INFO] [WallTime: 1455169354.372014] [5.020000] check 4 collision status, 0.796813 Hz
[hrpsys_py-4] process has died [pid 6072, exit code -11, cmd /home/k-okada/catkin_ws/ws_hironx/src/rtmros_nextage/nextage_ros_bridge/script/nextage.py HiroNX(Robot)0 /home/k-okada/catkin_ws/ws_hironx/src/rtmros_nextage/nextage_description/models/main.wrl -ORBInitRef NameService=corbaloc:iiop:localhost:15005/NameService __name:=hrpsys_py __log:=/home/k-okada/.ros/log/35efa6b8-d082-11e5-87bb-28b2bde75e69/hrpsys_py-4.log].
```

The problems is that the `hironx_py` or `nextage.py` did not exit cleanly, exit with -11.

This is tese code to catch this and I have noticed removing https://github.com/start-jsk/rtmros_hironx/pull/422/files#diff-857478fb2f83dd45b4a5fee7ca797b9cR74 line will disapper the error, but this work around may not correct

I think there are two possible reason
1. running MoveitCommander without running moveit may have some trouble
2. running MoveitCommander with rospy may have some troubles.

MoveitCommander may have roscpp initialization process inside, so they may have some side effects on signal handling, I guess.
https://github.com/ros-planning/moveit_commander/blob/indigo-devel/src/moveit_commander/roscpp_initializer.py
