### PR TITLE
Add a QNX-compatible force sensor driver code (with HiroNXO specific customization)

### DIFF
--- a/hironx_ros_bridge/package.xml
+++ b/hironx_ros_bridge/package.xml
@@ -4,6 +4,8 @@
   <description>ROS-OpenRTM interfacing package for the opensource version of Kawada's Hiro/NEXTAGE dual-arm robot.
 
   NOTE: This package is multi-license -- pay attention to file header in each file where license is declared. For Creative Commons nc 4.0 applied, see <a href = "http://creativecommons.org/licenses/by-nc/4.0">here</a>.
+
+  <p>This package also contains some sensor driver software (as of April 2016 they are the following force sensors such as <a href = "http://www.wacoh-tech.com/products/dynpick/wdf-6m200-3.html">Dynpick</a> and <a href = "http://www.jr3.com/products.html">JR3</a>) for QNX. These drivers are stored in this robot-specific package for not many reasons than they are slightly customized for the robot. So if you can separate those as a standalone, generic package that'll be appreciated (please just let us know if you will).</p>
   </description>
 
   <maintainer email="k-okada@jsk.t.u-tokyo.ac.jp">Kei Okada</maintainer>

--- a/hironx_ros_bridge/robot/dynpick/Makefile
+++ b/hironx_ros_bridge/robot/dynpick/Makefile
@@ -1,0 +1,11 @@
+all: dynpick_driver sample_dynpick test-com
+
+dynpick_driver: dynpick_driver.cpp
+	g++ -o dynpick_driver dynpick_driver.cpp
+
+sample_dynpick: sample_dynpick.c
+	gcc -o $@ $^
+
+test-com: test-com.c
+	gcc -o $@ $^
+

--- a/hironx_ros_bridge/robot/dynpick/dynpick_driver.cpp
+++ b/hironx_ros_bridge/robot/dynpick/dynpick_driver.cpp
@@ -105,7 +105,7 @@ int SetComAttr(int fdc) {
 
 int ReadCom(int fdc, unsigned short *data) {
 	int tick;
-	char str[256];
+	char str[255];
 	int n, len;
 
 #define DATA_LENGTH 27
@@ -252,7 +252,7 @@ int message_callback(message_context_t * ctp, int type, unsigned flags,
 	}
 
 	/* Send a reply to the waiting (blocked) client */
-	MsgReply(ctp->rcvid, EOK, msg_reply, 256);
+	MsgReply(ctp->rcvid, EOK, msg_reply, 255);
 	return 0;
 }
 

--- a/hironx_ros_bridge/robot/dynpick/dynpick_driver.cpp
+++ b/hironx_ros_bridge/robot/dynpick/dynpick_driver.cpp
@@ -1,0 +1,465 @@
+/*
+ * This program is based on http://github.com/tork-a/dynpick_driver and http://github.com/start-jsk/rtmros_hironx/blob/indigo-devel/hironx_ros_bridge/robot/nitta/jr3_driver.cpp
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/time.h>
+#include <sys/neutrino.h>
+#include <sys/iofunc.h>
+#include <sys/dispatch.h>
+#include <sys/mman.h>
+
+#include <sys/slog.h>
+
+#include	<fcntl.h>
+#include	<termios.h>
+
+unsigned short	force_sensor_data_0[6];
+unsigned short	force_sensor_data_1[6];
+
+/*
+ * serial stuff
+ */
+
+#define cfsetspeed(term, baudrate)\
+   cfsetispeed(term, baudrate);\
+   cfsetospeed(term, baudrate);
+
+
+int SetComAttr(int fdc)
+{
+        int res = -1;
+	if (fdc < 0)
+	     {
+		char *pmesg = strerror(errno);
+		fprintf (stderr, "failed to open : %s\n", pmesg);
+		goto over;
+	     }
+	   
+	   
+	struct termios term;
+	res = tcgetattr(fdc, &term);
+
+	if (res<0)
+	     {
+		char *pmesg = strerror(errno);
+		fprintf (stderr, "failed to tcgetattr(): %s\n", pmesg);
+		goto over;
+	     }
+	 cfmakeraw(&term);
+	 res = cfsetspeed(&term, 921600);
+	 if (res<0) 
+	     {
+		
+		char *pmesg = strerror(errno);
+		fprintf (stderr, "failed to cfsetspeed(): %s\n", pmesg);
+		goto over;
+	     }
+
+	 // settings for qnx
+	 term.c_iflag |= IGNPAR;            // Ignore characters with parity errors
+	 term.c_cflag |= (CLOCAL | CREAD);  // needed for QNX 6.3.2
+	 term.c_cflag &= ~PARENB;           // disable parity check
+	 term.c_cflag |= CS8;               // 8 data bit
+	 term.c_cflag &= ~CSTOPB;           // 1 stop bit
+	 //term.c_lflag = IEXTEN;
+	 term.c_oflag = 0; ///added
+	 term.c_lflag &= ~(ECHO | ECHOCTL | ECHONL);  // disable ECHO
+	   
+	 //
+	 term.c_iflag &= ~INPCK;
+
+	 // settings for dynpick
+	   term.c_cc[VINTR]    = 0;     /* Ctrl-c */
+	   term.c_cc[VQUIT]    = 0;     /* Ctrl-? */	   term.c_cc[VERASE]   = 0;     /* del */
+	   term.c_cc[VKILL]    = 0;     /* @ */
+	   term.c_cc[VEOF]     = 4;     /* Ctrl-d */
+	   term.c_cc[VTIME]    = 0;
+	   term.c_cc[VMIN]     = 0;
+	   //term.c_cc[VSWTC]    = 0;     /* '?0' */
+	   term.c_cc[VSTART]   = 0;     /* Ctrl-q */ 
+	   term.c_cc[VSTOP]    = 0;     /* Ctrl-s */
+	   term.c_cc[VSUSP]    = 0;     /* Ctrl-z */
+	   term.c_cc[VEOL]     = 0;     /* '?0' */
+	   term.c_cc[VREPRINT] = 0;     /* Ctrl-r */
+	   term.c_cc[VDISCARD] = 0;     /* Ctrl-u */
+	   term.c_cc[VWERASE]  = 0;     /* Ctrl-w */
+	   term.c_cc[VLNEXT]   = 0;     /* Ctrl-v */
+	   term.c_cc[VEOL2]    = 0;     /* '?0' */
+#ifdef __QNX__
+	 term.c_cflag &= ~(IHFLOW | OHFLOW);
+#endif
+
+	 // settings for qnx
+	 term.c_cc[VMIN] = 100;
+	 term.c_cc[VTIME] = 0;
+
+	 res = tcsetattr(fdc, TCSANOW, &term);
+	 if (res<0) 
+	     {
+		char *pmesg = strerror(errno);
+		fprintf (stderr, "failed to tcsetattr(): %s\n", pmesg);
+		goto over;
+	     }
+
+   over :
+	return (res);
+}
+
+
+int ReadCom(int fdc, unsigned short *data)
+{
+   int			tick;
+   char			str[256];
+   int			n, len;
+
+#define DATA_LENGTH 27
+   if (fdc < 0 ) return DATA_LENGTH; // dummy data
+
+   // Data Request
+   n = write(fdc, "R", 1);
+   tcdrain(fdc);
+   printf("write data ret=%d, fd=%d\n", n, fdc);
+
+   // Get Singale data
+   len = 0;
+   bzero(str, 27);
+   while ( len < DATA_LENGTH ) 
+     {
+	n = read(fdc, str+len, DATA_LENGTH-len);
+	printf("read data %d (%d)\n", n, len);
+	if ( n > 0 ) 
+	  {
+	     len += n;
+	  }
+	else
+	  {
+	     char *pmesg = strerror(errno);
+	     fprintf (stderr, "failed to read data (ret=%d, fd=%d): %s (%d)\n", n, fdc, pmesg, errno);
+		  goto loop_exit;
+	  }
+     }
+   loop_exit :
+     {
+	int i;
+	for(i = 0; i < DATA_LENGTH;i++)
+	  {
+	     fprintf(stderr, "%02x:", 0x0000ff & str[i]);
+	  }
+	fprintf(stderr, "\n");
+     }
+	     
+
+   sscanf(str, "%1d%4hx%4hx%4hx%4hx%4hx%4hx",
+	  &tick, &data[0], &data[1], &data[2], &data[3], &data[4], &data[5]);
+   
+   sprintf(str, "%d,%05d,%05d,%05d,%05d,%05d,%05d\n",
+	   tick,
+	   data[0], data[1], data[2], data[3], data[4], data[5]);
+   
+   return len;
+}
+
+/*
+ * message stuff
+ */
+
+#define min(a, b) ((a) < (b) ? (a) : (b))
+
+int io_read (resmgr_context_t * ctp, io_read_t * msg, RESMGR_OCB_T * ocb);	//
+static char *buffer = (char *) "Hello world\n";	//
+
+void wait_t (void);		// wait for 3 sec.
+
+static resmgr_connect_funcs_t ConnectFuncs;	//
+static resmgr_io_funcs_t IoFuncs;	//
+static iofunc_attr_t IoFuncAttr;	//
+
+
+typedef struct
+{
+  uint16_t msg_no;
+  char msg_data[255];
+} server_msg_t;
+
+int
+message_callback (message_context_t * ctp, int type, unsigned flags,
+		  void *handle)
+{
+  server_msg_t *msg;
+  int num;
+  char msg_reply[255];
+
+  /* cast a pointer to the message data */
+  msg = (server_msg_t *) ctp->msg;
+
+  /* Print out some usefull information on the message */
+  //printf( "\n\nServer Got Message:\n" );
+  //printf( "  type: %d\n" , type );
+  //printf( "  data: %s\n\n", msg->msg_data );
+
+#if 0
+  force_sensor_data *data_0;
+  force_sensor_data *data_1;
+  data_0 = (force_sensor_data *) (Jr3BaseAddress0H + (Jr3DmAddrMask << 2));
+  data_1 = (force_sensor_data *) (Jr3BaseAddress1H + (Jr3DmAddrMask << 2));
+#endif
+  /* Build the reply message */
+  num = type - _IO_MAX;
+  switch (num)
+    {
+    case 1:			// get data
+      {
+#if 0  // FIX ME
+	float tmp[12] = {
+	  -1.0 * (float) data_0->filter0.fx / (float) data_0->full_scale.fx,
+	  -1.0 * (float) data_0->filter0.fy / (float) data_0->full_scale.fy,
+	  -1.0 * (float) data_0->filter0.fz / (float) data_0->full_scale.fz,
+	  -1.0 * (float) data_0->filter0.mx / (float) data_0->full_scale.mx * 0.1, // Newton*meter*10
+	  -1.0 * (float) data_0->filter0.my / (float) data_0->full_scale.my * 0.1,
+	  -1.0 * (float) data_0->filter0.mz / (float) data_0->full_scale.mz * 0.1,
+	  -1.0 * (float) data_1->filter0.fx / (float) data_1->full_scale.fx,
+	  -1.0 * (float) data_1->filter0.fy / (float) data_1->full_scale.fy,
+	  -1.0 * (float) data_1->filter0.fz / (float) data_1->full_scale.fz,
+	  -1.0 * (float) data_1->filter0.mx / (float) data_1->full_scale.mx * 0.1,
+	  -1.0 * (float) data_1->filter0.my / (float) data_1->full_scale.my * 0.1,
+	  -1.0 * (float) data_1->filter0.mz / (float) data_1->full_scale.mz * 0.1
+	};
+#endif	 
+	 float tmp[12] = 
+	   {
+	      (force_sensor_data_0[0]-8192)/1000.0,
+	      (force_sensor_data_0[1]-8192)/1000.0,		
+	      (force_sensor_data_0[2]-8192)/1000.0,
+	      (force_sensor_data_0[3]-8192)/1000.0,
+	      (force_sensor_data_0[4]-8192)/1000.0,
+	      (force_sensor_data_0[5]-8192)/1000.0,
+	      (force_sensor_data_1[0]-8192)/1000.0,
+	      (force_sensor_data_1[1]-8192)/1000.0,		
+	      (force_sensor_data_1[2]-8192)/1000.0,
+	      (force_sensor_data_1[3]-8192)/1000.0,
+	      (force_sensor_data_1[4]-8192)/1000.0,
+	      (force_sensor_data_1[5]-8192)/1000.0,
+	   }
+	 ;
+	 memcpy (msg_reply, tmp, sizeof (float) * 12);
+
+      }
+      break;
+    case 2:			// update offset
+#if 0 // FIX ME
+      data_0->offsets.fx += data_0->filter0.fx;
+      data_0->offsets.fy += data_0->filter0.fy;
+      data_0->offsets.fz += data_0->filter0.fz;
+      data_0->offsets.mx += data_0->filter0.mx;
+      data_0->offsets.my += data_0->filter0.my;
+      data_0->offsets.mz += data_0->filter0.mz;
+      data_1->offsets.fx += data_1->filter0.fx;
+      data_1->offsets.fy += data_1->filter0.fy;
+      data_1->offsets.fz += data_1->filter0.fz;
+      data_1->offsets.mx += data_1->filter0.mx;
+      data_1->offsets.my += data_1->filter0.my;
+      data_1->offsets.mz += data_1->filter0.mz;
+#endif       
+      break;
+    case 3:			// set filter
+      break;
+    case 4:			// get data
+#if 0        // FIX ME
+      get_force_sensor_info (data_0, msg_reply);
+      get_force_sensor_info (data_1, msg_reply + strlen (msg_reply));
+#endif       
+      break;
+    }
+
+  /* Send a reply to the waiting (blocked) client */
+  MsgReply (ctp->rcvid, EOK, msg_reply, 256);
+  return 0;
+}
+
+
+int
+main (int argc, char **argv)
+{
+  resmgr_attr_t resmgr_attr;
+  message_attr_t message_attr;
+  dispatch_t *dpp;
+  dispatch_context_t *ctp, *ctp_ret;
+  int resmgr_id, message_id;
+  int fd1, fd2;
+
+  /* Open Serial port */
+  fd1 = open("/dev/serusb1", O_RDWR | O_NOCTTY | O_NONBLOCK );
+  if (fd1 < 0 ) 
+     {
+	fprintf(stderr, "could not open /dev/serusb1\n");
+     }
+  fd2 = open("/dev/serusb2", O_RDWR | O_NOCTTY | O_NONBLOCK );
+  if (fd2 < 0 )
+     {
+	fprintf(stderr, "could not open /dev/serusb2\n");
+     }
+   
+  slogf(0, _SLOG_INFO, "Started  fd1 = %d, fd2 = %d\n", fd1, fd2);
+  SetComAttr(fd1);
+  SetComAttr(fd2);   
+   
+  /* Create the Dispatch Interface */
+  dpp = dispatch_create ();
+  if (dpp == NULL)
+    {
+      fprintf (stderr, "dispatch_create() failed: %s\n", strerror (errno));
+      return EXIT_FAILURE;
+    }
+
+  memset (&resmgr_attr, 0, sizeof (resmgr_attr));
+  resmgr_attr.nparts_max = 1;
+  resmgr_attr.msg_max_size = 2048;
+
+  /* Setup the default I/O functions to handle open/read/write/... */
+  iofunc_func_init (_RESMGR_CONNECT_NFUNCS, &ConnectFuncs,
+		    _RESMGR_IO_NFUNCS, &IoFuncs);
+
+  IoFuncs.read = io_read;
+
+  /* Setup the attribute for the entry in the filesystem */
+  iofunc_attr_init (&IoFuncAttr, S_IFNAM | 0666, 0, 0);
+  IoFuncAttr.nbytes = strlen (buffer) + 1;	//
+
+  resmgr_id = resmgr_attach (dpp, &resmgr_attr, "/dev/jr3q", _FTYPE_ANY,
+			     0, &ConnectFuncs, &IoFuncs, &IoFuncAttr);
+  if (resmgr_id == -1)
+    {
+      fprintf (stderr, "resmgr_attach() failed: %s\n", strerror (errno));
+      return EXIT_FAILURE;
+    }
+   
+  /* Setup Serial Port */
+
+  /* Setup our message callback */
+  memset (&message_attr, 0, sizeof (message_attr));
+  message_attr.nparts_max = 1;
+  message_attr.msg_max_size = 4096;
+
+  /* Attach a callback (handler) for two message types */
+  message_id = message_attach (dpp, &message_attr, _IO_MAX + 1,
+			       _IO_MAX + 10, message_callback, NULL);
+  if (message_id == -1)
+    {
+      fprintf (stderr, "message_attach() failed: %s\n", strerror (errno));
+      return EXIT_FAILURE;
+    }
+
+  /* Setup a context for the dispatch layer to use */
+  ctp = dispatch_context_alloc (dpp);
+  if (ctp == NULL)
+    {
+      fprintf (stderr, "dispatch_context_alloc() failed: %s\n",
+	       strerror (errno));
+      return EXIT_FAILURE;
+    }
+
+  /* The "Data Pump" - get and process messages */
+  while (1)
+    {
+      /* do serial read */
+      ReadCom(fd1, force_sensor_data_0);
+      ReadCom(fd2, force_sensor_data_1);       
+
+       printf("dispatch\n");
+      /* process message */
+      ctp_ret = dispatch_block (ctp);
+      if (ctp_ret)
+	{
+	  dispatch_handler (ctp);
+	}
+      else
+	{
+	  fprintf (stderr, "dispatch_block() failed: %s\n", strerror (errno));
+	  return EXIT_FAILURE;
+	}
+    }
+
+  return EXIT_SUCCESS;
+}
+
+
+int
+io_read (resmgr_context_t * ctp, io_read_t * msg, RESMGR_OCB_T * ocb)
+{
+  int nleft;
+  int nbytes;
+  int nparts;
+  int status;
+
+  if ((status = iofunc_read_verify (ctp, msg, ocb, NULL)) != EOK)
+    return (status);
+
+  if ((msg->i.xtype & _IO_XTYPE_MASK) != _IO_XTYPE_NONE)
+    return (ENOSYS);
+
+  /*
+   * on all reads (first and subsequent) calculate
+   * how many bytes we can return to the client,
+   * based upon the number of bytes available (nleft)
+   * and the client's buffer size
+   */
+
+  nleft = ocb->attr->nbytes - ocb->offset;
+  nbytes = min (msg->i.nbytes, nleft);
+
+  if (nbytes > 0)
+    {
+      /* set up the return data IOV */
+      SETIOV (ctp->iov, buffer + ocb->offset, nbytes);
+
+      /* set up the number of bytes (returned by client's read()) */
+      _IO_SET_READ_NBYTES (ctp, nbytes);
+
+      /*
+       * advance the offset by the number of bytes
+       * returned to the client.
+       */
+
+      ocb->offset += nbytes;
+      nparts = 1;
+    }
+  else
+    {
+      /* they've adked for zero bytes or they've already previously
+       * read everything
+       */
+
+      _IO_SET_READ_NBYTES (ctp, 0);
+      nparts = 0;
+    }
+
+  /* mark the access time as invalid (we just accessed it) */
+
+  if (msg->i.nbytes > 0)
+    ocb->attr->flags |= IOFUNC_ATTR_ATIME;
+
+  return (_RESMGR_NPARTS (nparts));
+
+
+}
+
+void
+wait_t (void)
+{
+  struct timeval tv, tv1;
+
+  gettimeofday (&tv1, NULL);
+
+  do
+    {
+      gettimeofday (&tv, NULL);
+    }
+  while (tv.tv_sec - tv1.tv_sec < 3);	// wait for 3 sec.
+
+  return;
+}

--- a/hironx_ros_bridge/robot/dynpick/dynpick_driver.cpp
+++ b/hironx_ros_bridge/robot/dynpick/dynpick_driver.cpp
@@ -18,8 +18,8 @@
 #include	<fcntl.h>
 #include	<termios.h>
 
-unsigned short	force_sensor_data_0[6];
-unsigned short	force_sensor_data_1[6];
+unsigned short force_sensor_data_0[6];
+unsigned short force_sensor_data_1[6];
 
 /*
  * serial stuff
@@ -29,36 +29,31 @@ unsigned short	force_sensor_data_1[6];
    cfsetispeed(term, baudrate);\
    cfsetospeed(term, baudrate);
 
-
-int SetComAttr(int fdc)
-{
-        int res = -1;
-	if (fdc < 0)
-	     {
+int SetComAttr(int fdc) {
+	int res = -1;
+	if (fdc < 0) {
 		char *pmesg = strerror(errno);
-		fprintf (stderr, "failed to open : %s\n", pmesg);
+		fprintf(stderr, "failed to open : %s\n", pmesg);
 		goto over;
-	     }
-	   
-	   
+	}
+
 	struct termios term;
 	res = tcgetattr(fdc, &term);
 
-	if (res<0)
-	     {
+	if (res < 0) {
 		char *pmesg = strerror(errno);
-		fprintf (stderr, "failed to tcgetattr(): %s\n", pmesg);
+		fprintf(stderr, "failed to tcgetattr(): %s\n", pmesg);
 		goto over;
-	     }
-	 cfmakeraw(&term);
-	 res = cfsetspeed(&term, 921600);
-	 if (res<0) 
-	     {
-		
+	}
+	cfmakeraw(&term);
+	res = cfsetspeed(&term, 921600)
+	;
+	if (res < 0) {
+
 		char *pmesg = strerror(errno);
-		fprintf (stderr, "failed to cfsetspeed(): %s\n", pmesg);
+		fprintf(stderr, "failed to cfsetspeed(): %s\n", pmesg);
 		goto over;
-	     }
+	}
 
 	 // settings for qnx
 	 term.c_iflag |= IGNPAR;            // Ignore characters with parity errors
@@ -91,77 +86,67 @@ int SetComAttr(int fdc)
 	   term.c_cc[VLNEXT]   = 0;     /* Ctrl-v */
 	   term.c_cc[VEOL2]    = 0;     /* '?0' */
 #ifdef __QNX__
-	 term.c_cflag &= ~(IHFLOW | OHFLOW);
+	term.c_cflag &= ~(IHFLOW | OHFLOW);
 #endif
 
-	 // settings for qnx
-	 term.c_cc[VMIN] = 100;
-	 term.c_cc[VTIME] = 0;
+	// settings for qnx
+	term.c_cc[VMIN] = 100;
+	term.c_cc[VTIME] = 0;
 
-	 res = tcsetattr(fdc, TCSANOW, &term);
-	 if (res<0) 
-	     {
+	res = tcsetattr(fdc, TCSANOW, &term);
+	if (res < 0) {
 		char *pmesg = strerror(errno);
-		fprintf (stderr, "failed to tcsetattr(): %s\n", pmesg);
+		fprintf(stderr, "failed to tcsetattr(): %s\n", pmesg);
 		goto over;
-	     }
+	}
 
-   over :
-	return (res);
+	over: return (res);
 }
 
-
-int ReadCom(int fdc, unsigned short *data)
-{
-   int			tick;
-   char			str[256];
-   int			n, len;
+int ReadCom(int fdc, unsigned short *data) {
+	int tick;
+	char str[256];
+	int n, len;
 
 #define DATA_LENGTH 27
-   if (fdc < 0 ) return DATA_LENGTH; // dummy data
+	if (fdc < 0)
+		return DATA_LENGTH; // dummy data
 
-   // Data Request
-   n = write(fdc, "R", 1);
-   tcdrain(fdc);
-   printf("write data ret=%d, fd=%d\n", n, fdc);
+	// Data Request
+	n = write(fdc, "R", 1);
+	tcdrain(fdc);
+	printf("write data ret=%d, fd=%d\n", n, fdc);
 
-   // Get Singale data
-   len = 0;
-   bzero(str, 27);
-   while ( len < DATA_LENGTH ) 
-     {
-	n = read(fdc, str+len, DATA_LENGTH-len);
-	printf("read data %d (%d)\n", n, len);
-	if ( n > 0 ) 
-	  {
-	     len += n;
-	  }
-	else
-	  {
-	     char *pmesg = strerror(errno);
-	     fprintf (stderr, "failed to read data (ret=%d, fd=%d): %s (%d)\n", n, fdc, pmesg, errno);
-		  goto loop_exit;
-	  }
-     }
-   loop_exit :
-     {
-	int i;
-	for(i = 0; i < DATA_LENGTH;i++)
-	  {
-	     fprintf(stderr, "%02x:", 0x0000ff & str[i]);
-	  }
-	fprintf(stderr, "\n");
-     }
-	     
+	// Get Singale data
+	len = 0;
+	bzero(str, 27);
+	while (len < DATA_LENGTH) {
+		n = read(fdc, str + len, DATA_LENGTH - len);
+		printf("read data %d (%d)\n", n, len);
+		if (n > 0) {
+			len += n;
+		} else {
+			char *pmesg = strerror(errno);
+			fprintf(stderr, "failed to read data (ret=%d, fd=%d): %s (%d)\n", n,
+					fdc, pmesg, errno);
+			goto loop_exit;
+		}
+	}
+	loop_exit: {
+		int i;
+		for (i = 0; i < DATA_LENGTH; i++) {
+			fprintf(stderr, "%02x:", 0x0000ff & str[i]);
+		}
+		fprintf(stderr, "\n");
+	}
 
-   sscanf(str, "%1d%4hx%4hx%4hx%4hx%4hx%4hx",
-	  &tick, &data[0], &data[1], &data[2], &data[3], &data[4], &data[5]);
-   
-   sprintf(str, "%d,%05d,%05d,%05d,%05d,%05d,%05d\n",
-	   tick,
-	   data[0], data[1], data[2], data[3], data[4], data[5]);
-   
-   return len;
+	sscanf(str, "%1d%4hx%4hx%4hx%4hx%4hx%4hx", &tick, &data[0], &data[1],
+			&data[2], &data[3], &data[4], &data[5]);
+
+	sprintf(str, "%d,%05d,%05d,%05d,%05d,%05d,%05d\n", tick, data[0], data[1],
+			data[2], data[3], data[4], data[5]);
+
+	return len;
 }
 
 /*
@@ -170,296 +155,262 @@ int ReadCom(int fdc, unsigned short *data)
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
-int io_read (resmgr_context_t * ctp, io_read_t * msg, RESMGR_OCB_T * ocb);	//
+int io_read(resmgr_context_t * ctp, io_read_t * msg, RESMGR_OCB_T * ocb);	//
 static char *buffer = (char *) "Hello world\n";	//
 
-void wait_t (void);		// wait for 3 sec.
+void wait_t(void);		// wait for 3 sec.
 
 static resmgr_connect_funcs_t ConnectFuncs;	//
 static resmgr_io_funcs_t IoFuncs;	//
 static iofunc_attr_t IoFuncAttr;	//
 
-
-typedef struct
-{
-  uint16_t msg_no;
-  char msg_data[255];
+typedef struct {
+	uint16_t msg_no;
+	char msg_data[255];
 } server_msg_t;
 
-int
-message_callback (message_context_t * ctp, int type, unsigned flags,
-		  void *handle)
-{
-  server_msg_t *msg;
-  int num;
-  char msg_reply[255];
+int message_callback(message_context_t * ctp, int type, unsigned flags,
+		void *handle) {
+	server_msg_t *msg;
+	int num;
+	char msg_reply[255];
 
-  /* cast a pointer to the message data */
-  msg = (server_msg_t *) ctp->msg;
+	/* cast a pointer to the message data */
+	msg = (server_msg_t *) ctp->msg;
 
-  /* Print out some usefull information on the message */
-  //printf( "\n\nServer Got Message:\n" );
-  //printf( "  type: %d\n" , type );
-  //printf( "  data: %s\n\n", msg->msg_data );
-
+	/* Print out some usefull information on the message */
+	//printf( "\n\nServer Got Message:\n" );
+	//printf( "  type: %d\n" , type );
+	//printf( "  data: %s\n\n", msg->msg_data );
 #if 0
-  force_sensor_data *data_0;
-  force_sensor_data *data_1;
-  data_0 = (force_sensor_data *) (Jr3BaseAddress0H + (Jr3DmAddrMask << 2));
-  data_1 = (force_sensor_data *) (Jr3BaseAddress1H + (Jr3DmAddrMask << 2));
+	force_sensor_data *data_0;
+	force_sensor_data *data_1;
+	data_0 = (force_sensor_data *) (Jr3BaseAddress0H + (Jr3DmAddrMask << 2));
+	data_1 = (force_sensor_data *) (Jr3BaseAddress1H + (Jr3DmAddrMask << 2));
 #endif
-  /* Build the reply message */
-  num = type - _IO_MAX;
-  switch (num)
-    {
-    case 1:			// get data
-      {
+	/* Build the reply message */
+	num = type - _IO_MAX;
+	switch (num) {
+	case 1:			// get data
+	{
 #if 0  // FIX ME
-	float tmp[12] = {
-	  -1.0 * (float) data_0->filter0.fx / (float) data_0->full_scale.fx,
-	  -1.0 * (float) data_0->filter0.fy / (float) data_0->full_scale.fy,
-	  -1.0 * (float) data_0->filter0.fz / (float) data_0->full_scale.fz,
-	  -1.0 * (float) data_0->filter0.mx / (float) data_0->full_scale.mx * 0.1, // Newton*meter*10
-	  -1.0 * (float) data_0->filter0.my / (float) data_0->full_scale.my * 0.1,
-	  -1.0 * (float) data_0->filter0.mz / (float) data_0->full_scale.mz * 0.1,
-	  -1.0 * (float) data_1->filter0.fx / (float) data_1->full_scale.fx,
-	  -1.0 * (float) data_1->filter0.fy / (float) data_1->full_scale.fy,
-	  -1.0 * (float) data_1->filter0.fz / (float) data_1->full_scale.fz,
-	  -1.0 * (float) data_1->filter0.mx / (float) data_1->full_scale.mx * 0.1,
-	  -1.0 * (float) data_1->filter0.my / (float) data_1->full_scale.my * 0.1,
-	  -1.0 * (float) data_1->filter0.mz / (float) data_1->full_scale.mz * 0.1
-	};
+		float tmp[12] = {
+			-1.0 * (float) data_0->filter0.fx / (float) data_0->full_scale.fx,
+			-1.0 * (float) data_0->filter0.fy / (float) data_0->full_scale.fy,
+			-1.0 * (float) data_0->filter0.fz / (float) data_0->full_scale.fz,
+			-1.0 * (float) data_0->filter0.mx / (float) data_0->full_scale.mx * 0.1, // Newton*meter*10
+			-1.0 * (float) data_0->filter0.my / (float) data_0->full_scale.my * 0.1,
+			-1.0 * (float) data_0->filter0.mz / (float) data_0->full_scale.mz * 0.1,
+			-1.0 * (float) data_1->filter0.fx / (float) data_1->full_scale.fx,
+			-1.0 * (float) data_1->filter0.fy / (float) data_1->full_scale.fy,
+			-1.0 * (float) data_1->filter0.fz / (float) data_1->full_scale.fz,
+			-1.0 * (float) data_1->filter0.mx / (float) data_1->full_scale.mx * 0.1,
+			-1.0 * (float) data_1->filter0.my / (float) data_1->full_scale.my * 0.1,
+			-1.0 * (float) data_1->filter0.mz / (float) data_1->full_scale.mz * 0.1
+		};
 #endif	 
-	 float tmp[12] = 
-	   {
-	      (force_sensor_data_0[0]-8192)/1000.0,
-	      (force_sensor_data_0[1]-8192)/1000.0,		
-	      (force_sensor_data_0[2]-8192)/1000.0,
-	      (force_sensor_data_0[3]-8192)/1000.0,
-	      (force_sensor_data_0[4]-8192)/1000.0,
-	      (force_sensor_data_0[5]-8192)/1000.0,
-	      (force_sensor_data_1[0]-8192)/1000.0,
-	      (force_sensor_data_1[1]-8192)/1000.0,		
-	      (force_sensor_data_1[2]-8192)/1000.0,
-	      (force_sensor_data_1[3]-8192)/1000.0,
-	      (force_sensor_data_1[4]-8192)/1000.0,
-	      (force_sensor_data_1[5]-8192)/1000.0,
-	   }
-	 ;
-	 memcpy (msg_reply, tmp, sizeof (float) * 12);
+		float tmp[12] = { (force_sensor_data_0[0] - 8192) / 1000.0,
+				(force_sensor_data_0[1] - 8192) / 1000.0,
+				(force_sensor_data_0[2] - 8192) / 1000.0,
+				(force_sensor_data_0[3] - 8192) / 1000.0,
+				(force_sensor_data_0[4] - 8192) / 1000.0,
+				(force_sensor_data_0[5] - 8192) / 1000.0,
+				(force_sensor_data_1[0] - 8192) / 1000.0,
+				(force_sensor_data_1[1] - 8192) / 1000.0,
+				(force_sensor_data_1[2] - 8192) / 1000.0,
+				(force_sensor_data_1[3] - 8192) / 1000.0,
+				(force_sensor_data_1[4] - 8192) / 1000.0,
+				(force_sensor_data_1[5] - 8192) / 1000.0, };
+		memcpy(msg_reply, tmp, sizeof(float) * 12);
 
-      }
-      break;
-    case 2:			// update offset
+	}
+		break;
+	case 2:			// update offset
 #if 0 // FIX ME
-      data_0->offsets.fx += data_0->filter0.fx;
-      data_0->offsets.fy += data_0->filter0.fy;
-      data_0->offsets.fz += data_0->filter0.fz;
-      data_0->offsets.mx += data_0->filter0.mx;
-      data_0->offsets.my += data_0->filter0.my;
-      data_0->offsets.mz += data_0->filter0.mz;
-      data_1->offsets.fx += data_1->filter0.fx;
-      data_1->offsets.fy += data_1->filter0.fy;
-      data_1->offsets.fz += data_1->filter0.fz;
-      data_1->offsets.mx += data_1->filter0.mx;
-      data_1->offsets.my += data_1->filter0.my;
-      data_1->offsets.mz += data_1->filter0.mz;
+	data_0->offsets.fx += data_0->filter0.fx;
+	data_0->offsets.fy += data_0->filter0.fy;
+	data_0->offsets.fz += data_0->filter0.fz;
+	data_0->offsets.mx += data_0->filter0.mx;
+	data_0->offsets.my += data_0->filter0.my;
+	data_0->offsets.mz += data_0->filter0.mz;
+	data_1->offsets.fx += data_1->filter0.fx;
+	data_1->offsets.fy += data_1->filter0.fy;
+	data_1->offsets.fz += data_1->filter0.fz;
+	data_1->offsets.mx += data_1->filter0.mx;
+	data_1->offsets.my += data_1->filter0.my;
+	data_1->offsets.mz += data_1->filter0.mz;
 #endif       
-      break;
-    case 3:			// set filter
-      break;
-    case 4:			// get data
+		break;
+	case 3:			// set filter
+		break;
+	case 4:			// get data
 #if 0        // FIX ME
-      get_force_sensor_info (data_0, msg_reply);
-      get_force_sensor_info (data_1, msg_reply + strlen (msg_reply));
+	get_force_sensor_info (data_0, msg_reply);
+	get_force_sensor_info (data_1, msg_reply + strlen (msg_reply));
 #endif       
-      break;
-    }
-
-  /* Send a reply to the waiting (blocked) client */
-  MsgReply (ctp->rcvid, EOK, msg_reply, 256);
-  return 0;
-}
-
-
-int
-main (int argc, char **argv)
-{
-  resmgr_attr_t resmgr_attr;
-  message_attr_t message_attr;
-  dispatch_t *dpp;
-  dispatch_context_t *ctp, *ctp_ret;
-  int resmgr_id, message_id;
-  int fd1, fd2;
-
-  /* Open Serial port */
-  fd1 = open("/dev/serusb1", O_RDWR | O_NOCTTY | O_NONBLOCK );
-  if (fd1 < 0 ) 
-     {
-	fprintf(stderr, "could not open /dev/serusb1\n");
-     }
-  fd2 = open("/dev/serusb2", O_RDWR | O_NOCTTY | O_NONBLOCK );
-  if (fd2 < 0 )
-     {
-	fprintf(stderr, "could not open /dev/serusb2\n");
-     }
-   
-  slogf(0, _SLOG_INFO, "Started  fd1 = %d, fd2 = %d\n", fd1, fd2);
-  SetComAttr(fd1);
-  SetComAttr(fd2);   
-   
-  /* Create the Dispatch Interface */
-  dpp = dispatch_create ();
-  if (dpp == NULL)
-    {
-      fprintf (stderr, "dispatch_create() failed: %s\n", strerror (errno));
-      return EXIT_FAILURE;
-    }
-
-  memset (&resmgr_attr, 0, sizeof (resmgr_attr));
-  resmgr_attr.nparts_max = 1;
-  resmgr_attr.msg_max_size = 2048;
-
-  /* Setup the default I/O functions to handle open/read/write/... */
-  iofunc_func_init (_RESMGR_CONNECT_NFUNCS, &ConnectFuncs,
-		    _RESMGR_IO_NFUNCS, &IoFuncs);
-
-  IoFuncs.read = io_read;
-
-  /* Setup the attribute for the entry in the filesystem */
-  iofunc_attr_init (&IoFuncAttr, S_IFNAM | 0666, 0, 0);
-  IoFuncAttr.nbytes = strlen (buffer) + 1;	//
-
-  resmgr_id = resmgr_attach (dpp, &resmgr_attr, "/dev/jr3q", _FTYPE_ANY,
-			     0, &ConnectFuncs, &IoFuncs, &IoFuncAttr);
-  if (resmgr_id == -1)
-    {
-      fprintf (stderr, "resmgr_attach() failed: %s\n", strerror (errno));
-      return EXIT_FAILURE;
-    }
-   
-  /* Setup Serial Port */
-
-  /* Setup our message callback */
-  memset (&message_attr, 0, sizeof (message_attr));
-  message_attr.nparts_max = 1;
-  message_attr.msg_max_size = 4096;
-
-  /* Attach a callback (handler) for two message types */
-  message_id = message_attach (dpp, &message_attr, _IO_MAX + 1,
-			       _IO_MAX + 10, message_callback, NULL);
-  if (message_id == -1)
-    {
-      fprintf (stderr, "message_attach() failed: %s\n", strerror (errno));
-      return EXIT_FAILURE;
-    }
-
-  /* Setup a context for the dispatch layer to use */
-  ctp = dispatch_context_alloc (dpp);
-  if (ctp == NULL)
-    {
-      fprintf (stderr, "dispatch_context_alloc() failed: %s\n",
-	       strerror (errno));
-      return EXIT_FAILURE;
-    }
-
-  /* The "Data Pump" - get and process messages */
-  while (1)
-    {
-      /* do serial read */
-      ReadCom(fd1, force_sensor_data_0);
-      ReadCom(fd2, force_sensor_data_1);       
-
-       printf("dispatch\n");
-      /* process message */
-      ctp_ret = dispatch_block (ctp);
-      if (ctp_ret)
-	{
-	  dispatch_handler (ctp);
+		break;
 	}
-      else
-	{
-	  fprintf (stderr, "dispatch_block() failed: %s\n", strerror (errno));
-	  return EXIT_FAILURE;
+
+	/* Send a reply to the waiting (blocked) client */
+	MsgReply(ctp->rcvid, EOK, msg_reply, 256);
+	return 0;
+}
+
+int main(int argc, char **argv) {
+	resmgr_attr_t resmgr_attr;
+	message_attr_t message_attr;
+	dispatch_t *dpp;
+	dispatch_context_t *ctp, *ctp_ret;
+	int resmgr_id, message_id;
+	int fd1, fd2;
+
+	/* Open Serial port */
+	fd1 = open("/dev/serusb1", O_RDWR | O_NOCTTY | O_NONBLOCK);
+	if (fd1 < 0) {
+		fprintf(stderr, "could not open /dev/serusb1\n");
 	}
-    }
+	fd2 = open("/dev/serusb2", O_RDWR | O_NOCTTY | O_NONBLOCK);
+	if (fd2 < 0) {
+		fprintf(stderr, "could not open /dev/serusb2\n");
+	}
 
-  return EXIT_SUCCESS;
+	slogf(0, _SLOG_INFO, "Started  fd1 = %d, fd2 = %d\n", fd1, fd2);
+	SetComAttr(fd1);
+	SetComAttr(fd2);
+
+	/* Create the Dispatch Interface */
+	dpp = dispatch_create();
+	if (dpp == NULL) {
+		fprintf(stderr, "dispatch_create() failed: %s\n", strerror(errno));
+		return EXIT_FAILURE;
+	}
+
+	memset(&resmgr_attr, 0, sizeof(resmgr_attr));
+	resmgr_attr.nparts_max = 1;
+	resmgr_attr.msg_max_size = 2048;
+
+	/* Setup the default I/O functions to handle open/read/write/... */
+	iofunc_func_init(_RESMGR_CONNECT_NFUNCS, &ConnectFuncs, _RESMGR_IO_NFUNCS,
+			&IoFuncs);
+
+	IoFuncs.read = io_read;
+
+	/* Setup the attribute for the entry in the filesystem */
+	iofunc_attr_init(&IoFuncAttr, S_IFNAM | 0666, 0, 0);
+	IoFuncAttr.nbytes = strlen(buffer) + 1;	//
+
+	resmgr_id = resmgr_attach(dpp, &resmgr_attr, "/dev/jr3q", _FTYPE_ANY, 0,
+			&ConnectFuncs, &IoFuncs, &IoFuncAttr);
+	if (resmgr_id == -1) {
+		fprintf(stderr, "resmgr_attach() failed: %s\n", strerror(errno));
+		return EXIT_FAILURE;
+	}
+
+	/* Setup Serial Port */
+
+	/* Setup our message callback */
+	memset(&message_attr, 0, sizeof(message_attr));
+	message_attr.nparts_max = 1;
+	message_attr.msg_max_size = 4096;
+
+	/* Attach a callback (handler) for two message types */
+	message_id = message_attach(dpp, &message_attr, _IO_MAX + 1, _IO_MAX + 10,
+			message_callback, NULL);
+	if (message_id == -1) {
+		fprintf(stderr, "message_attach() failed: %s\n", strerror(errno));
+		return EXIT_FAILURE;
+	}
+
+	/* Setup a context for the dispatch layer to use */
+	ctp = dispatch_context_alloc(dpp);
+	if (ctp == NULL) {
+		fprintf(stderr, "dispatch_context_alloc() failed: %s\n",
+				strerror(errno));
+		return EXIT_FAILURE;
+	}
+
+	/* The "Data Pump" - get and process messages */
+	while (1) {
+		/* do serial read */
+		ReadCom(fd1, force_sensor_data_0);
+		ReadCom(fd2, force_sensor_data_1);
+
+		printf("dispatch\n");
+		/* process message */
+		ctp_ret = dispatch_block(ctp);
+		if (ctp_ret) {
+			dispatch_handler(ctp);
+		} else {
+			fprintf(stderr, "dispatch_block() failed: %s\n", strerror(errno));
+			return EXIT_FAILURE;
+		}
+	}
+
+	return EXIT_SUCCESS;
 }
 
+int io_read(resmgr_context_t * ctp, io_read_t * msg, RESMGR_OCB_T * ocb) {
+	int nleft;
+	int nbytes;
+	int nparts;
+	int status;
 
-int
-io_read (resmgr_context_t * ctp, io_read_t * msg, RESMGR_OCB_T * ocb)
-{
-  int nleft;
-  int nbytes;
-  int nparts;
-  int status;
+	if ((status = iofunc_read_verify(ctp, msg, ocb, NULL)) != EOK)
+		return (status);
 
-  if ((status = iofunc_read_verify (ctp, msg, ocb, NULL)) != EOK)
-    return (status);
+	if ((msg->i.xtype & _IO_XTYPE_MASK) != _IO_XTYPE_NONE)
+		return (ENOSYS);
 
-  if ((msg->i.xtype & _IO_XTYPE_MASK) != _IO_XTYPE_NONE)
-    return (ENOSYS);
+	/*
+	 * on all reads (first and subsequent) calculate
+	 * how many bytes we can return to the client,
+	 * based upon the number of bytes available (nleft)
+	 * and the client's buffer size
+	 */
 
-  /*
-   * on all reads (first and subsequent) calculate
-   * how many bytes we can return to the client,
-   * based upon the number of bytes available (nleft)
-   * and the client's buffer size
-   */
+	nleft = ocb->attr->nbytes - ocb->offset;
+	nbytes = min(msg->i.nbytes, nleft);
 
-  nleft = ocb->attr->nbytes - ocb->offset;
-  nbytes = min (msg->i.nbytes, nleft);
+	if (nbytes > 0) {
+		/* set up the return data IOV */
+		SETIOV(ctp->iov, buffer + ocb->offset, nbytes);
 
-  if (nbytes > 0)
-    {
-      /* set up the return data IOV */
-      SETIOV (ctp->iov, buffer + ocb->offset, nbytes);
+		/* set up the number of bytes (returned by client's read()) */
+		_IO_SET_READ_NBYTES(ctp, nbytes);
 
-      /* set up the number of bytes (returned by client's read()) */
-      _IO_SET_READ_NBYTES (ctp, nbytes);
+		/*
+		 * advance the offset by the number of bytes
+		 * returned to the client.
+		 */
 
-      /*
-       * advance the offset by the number of bytes
-       * returned to the client.
-       */
+		ocb->offset += nbytes;
+		nparts = 1;
+	} else {
+		/* they've adked for zero bytes or they've already previously
+		 * read everything
+		 */
 
-      ocb->offset += nbytes;
-      nparts = 1;
-    }
-  else
-    {
-      /* they've adked for zero bytes or they've already previously
-       * read everything
-       */
+		_IO_SET_READ_NBYTES(ctp, 0);
+		nparts = 0;
+	}
 
-      _IO_SET_READ_NBYTES (ctp, 0);
-      nparts = 0;
-    }
+	/* mark the access time as invalid (we just accessed it) */
 
-  /* mark the access time as invalid (we just accessed it) */
+	if (msg->i.nbytes > 0)
+		ocb->attr->flags |= IOFUNC_ATTR_ATIME;
 
-  if (msg->i.nbytes > 0)
-    ocb->attr->flags |= IOFUNC_ATTR_ATIME;
-
-  return (_RESMGR_NPARTS (nparts));
-
+	return (_RESMGR_NPARTS(nparts));
 
 }
 
-void
-wait_t (void)
-{
-  struct timeval tv, tv1;
+void wait_t(void) {
+	struct timeval tv, tv1;
 
-  gettimeofday (&tv1, NULL);
+	gettimeofday(&tv1, NULL);
 
-  do
-    {
-      gettimeofday (&tv, NULL);
-    }
-  while (tv.tv_sec - tv1.tv_sec < 3);	// wait for 3 sec.
+	do {
+		gettimeofday(&tv, NULL);
+	} while (tv.tv_sec - tv1.tv_sec < 3);	// wait for 3 sec.
 
-  return;
+	return;
 }

--- a/hironx_ros_bridge/robot/dynpick/dynpick_driver.cpp
+++ b/hironx_ros_bridge/robot/dynpick/dynpick_driver.cpp
@@ -4,7 +4,7 @@
   This driver is stored in this robot-specific package for not many reasons than they are slightly customized for the robot (as of Apr 2016 it takes 2 sensor inputs in a single cpp file. It also assumes the specific device file name). So if you can separate those as a standalone, generic package that'll be appreciated (please just let us know if you will at https://github.com/start-jsk/rtmros_hironx/issues).
 */
 /*
- * This program is for JR3/Nitta Force moment sensor.
+ * This program is for Dynpick F/T sensor (developed from JR3 sensor).
  * Copyright(C) by Waseda University, Nitta Coropration. 2002.
  *
  * Copyright (c) 2016, TORK (Tokyo Opensource Robotics Kyokai Association)
@@ -40,14 +40,12 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <string.h>
-#include <sys/time.h>
-#include <sys/neutrino.h>
-#include <sys/iofunc.h>
 #include <sys/dispatch.h>
+#include <sys/iofunc.h>
 #include <sys/mman.h>
-
+#include <sys/neutrino.h>
 #include <sys/slog.h>
-
+#include <sys/time.h>
 #include	<fcntl.h>
 #include	<termios.h>
 
@@ -306,8 +304,9 @@ int main(int argc, char **argv) {
 	if (fd2 < 0) {
 		fprintf(stderr, "could not open /dev/serusb2\n");
 	}
-
-	slogf(0, _SLOG_INFO, "Started  fd1 = %d, fd2 = %d\n", fd1, fd2);
+        #ifdef __QNX__ 
+	    slogf(0, _SLOG_INFO, "Started  fd1 = %d, fd2 = %d\n", fd1, fd2);
+        #endif 
 	SetComAttr(fd1);
 	SetComAttr(fd2);
 

--- a/hironx_ros_bridge/robot/dynpick/dynpick_driver.cpp
+++ b/hironx_ros_bridge/robot/dynpick/dynpick_driver.cpp
@@ -114,7 +114,7 @@ int ReadCom(int fdc, unsigned short *data) {
 
 	// Data Request
 	n = write(fdc, "R", 1);
-	tcdrain(fdc);
+	//tcdrain(fdc);  // Old legacy that is no longer needed. Besideds that, on QNX6.5.0 this is found taking unnecessarily too long (say 100msec).
 	printf("write data ret=%d, fd=%d\n", n, fdc);
 
 	// Get Singale data

--- a/hironx_ros_bridge/robot/dynpick/dynpick_driver.cpp
+++ b/hironx_ros_bridge/robot/dynpick/dynpick_driver.cpp
@@ -1,5 +1,38 @@
 /*
  * This program is based on http://github.com/tork-a/dynpick_driver and http://github.com/start-jsk/rtmros_hironx/blob/indigo-devel/hironx_ros_bridge/robot/nitta/jr3_driver.cpp
+
+  This driver is stored in this robot-specific package for not many reasons than they are slightly customized for the robot (as of Apr 2016 it takes 2 sensor inputs in a single cpp file. It also assumes the specific device file name). So if you can separate those as a standalone, generic package that'll be appreciated (please just let us know if you will at https://github.com/start-jsk/rtmros_hironx/issues).
+*/
+/*
+ * This program is for JR3/Nitta Force moment sensor.
+ * Copyright(C) by Waseda University, Nitta Coropration. 2002.
+ *
+ * Copyright (c) 2016, TORK (Tokyo Opensource Robotics Kyokai Association)
+ * All rights reserved.
+ * # Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * #  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *  * Neither the name of TOKYO. nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <stdio.h>

--- a/hironx_ros_bridge/robot/dynpick/run_dynpick.sh
+++ b/hironx_ros_bridge/robot/dynpick/run_dynpick.sh
@@ -2,10 +2,12 @@
 
 # Written by TORK
 
-slay devc-serusb
-sleep 1
-devc-serusb -E -F -b 921600 -d busno=0,devno=1,vid=0x10c4,did=0xea60
-sleep 1
+# slay devc-serusb
+# sleep 1
+## devc-serusb needs to be that of QNX6.5.0 SP1, to recognize Dynpick WDF-6M200-3, which is USB-Serial with 921.6kbps.
+## And looks like we don't need to specifically call it as long as right version of /sbin/devc-serusb is placed.
+# devc-serusb -E -F -b 921600 -d busno=0,devno=1,vid=0x10c4,did=0xea60
+# sleep 1
 # stty < /dev/serusb1
 ./dynpick_driver
 # stty < /dev/serusb1

--- a/hironx_ros_bridge/robot/dynpick/run_dynpick.sh
+++ b/hironx_ros_bridge/robot/dynpick/run_dynpick.sh
@@ -9,5 +9,5 @@
 # devc-serusb -E -F -b 921600 -d busno=0,devno=1,vid=0x10c4,did=0xea60
 # sleep 1
 # stty < /dev/serusb1
-./dynpick_driver
+./dynpick_driver &
 # stty < /dev/serusb1

--- a/hironx_ros_bridge/robot/dynpick/run_dynpick.sh
+++ b/hironx_ros_bridge/robot/dynpick/run_dynpick.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+slay devc-serusb_qnx650sp1
+sleep 1
+./devc-serusb_qnx650sp1  -E -F -b 921600 -d module=ftdi,busno=0,devno=1,vid=0x0403,did=0x6001
+sleep 1
+stty < /dev/serusb1
+make
+./dynpick_driver
+stty < /dev/serusb1
+
+

--- a/hironx_ros_bridge/robot/dynpick/run_dynpick.sh
+++ b/hironx_ros_bridge/robot/dynpick/run_dynpick.sh
@@ -1,12 +1,11 @@
 #!/bin/sh
 
-slay devc-serusb_qnx650sp1
+# Written by TORK
+
+slay devc-serusb
 sleep 1
-./devc-serusb_qnx650sp1  -E -F -b 921600 -d module=ftdi,busno=0,devno=1,vid=0x0403,did=0x6001
+devc-serusb -E -F -b 921600 -d busno=0,devno=1,vid=0x10c4,did=0xea60
 sleep 1
-stty < /dev/serusb1
-make
+# stty < /dev/serusb1
 ./dynpick_driver
-stty < /dev/serusb1
-
-
+# stty < /dev/serusb1

--- a/hironx_ros_bridge/robot/dynpick/run_dynpick.sh
+++ b/hironx_ros_bridge/robot/dynpick/run_dynpick.sh
@@ -1,5 +1,33 @@
 #!/bin/sh
 
+# This program is for Dynpick F/T sensor for HiroNXO robot on QNX.
+# Copyright (c) 2016, TORK (Tokyo Opensource Robotics Kyokai Association)
+# All rights reserved.
+# * Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# * * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+# * Neither the name of TOKYO. nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without
+#    specific prior written permission.
+# * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 # Written by TORK
 
 # slay devc-serusb

--- a/hironx_ros_bridge/robot/dynpick/sample_dynpick.c
+++ b/hironx_ros_bridge/robot/dynpick/sample_dynpick.c
@@ -1,0 +1,122 @@
+/*
+ *  Message Client Process
+ *
+ *  This program is for JR3/Nitta Force moment sensor.
+ *  Copyright(C) by Waseda University, Nitta Corporation. 2002.
+ *
+ * Modified by Kei Okada, 2014
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/neutrino.h>
+#include <sys/iofunc.h>
+#include <sys/dispatch.h>
+#include <sys/mman.h>
+
+#define Jr3DmAddrMask	0x6000
+#define PAGE_SIZE	0x1000
+unsigned long MappedAddress;
+
+#define SENSOR0		0
+#define SENSOR1		0x80000
+#define SENSOR2		0x100000
+#define SENSOR3		0x180000
+
+typedef struct
+{
+  uint16_t msg_no;
+  char msg_data[255];
+} client_msg_t;
+
+int
+main (int argc, char **argv)
+{
+  int fd;
+  int c;
+  client_msg_t msg;
+  int ret;
+  int num;
+  char msg_reply[255];
+  int i;
+
+  printf ("\x1b[2J");
+  printf ("\x1b[0;0H");
+
+  num = 4;
+
+  /* Process any command line arguments */
+  while ((c = getopt (argc, argv, "n:")) != -1)
+    {
+      if (c == 'n')
+	{
+	  num = strtol (optarg, 0, 0);
+	}
+    }
+
+  /* Open a connection to the server (fd == coid) */
+  fd = open ("/dev/jr3q", O_RDWR);
+  if (fd == -1)
+    {
+      fprintf (stderr, "Unable to open server connection: %s\n",
+	       strerror (errno));
+      return EXIT_FAILURE;
+    }
+
+  /* Clear the memory for the msg and the reply */
+  memset (&msg, 0, sizeof (msg));
+  memset (&msg_reply, 0, sizeof (msg_reply));
+
+  /* Setup the message data to send to the server */
+  msg.msg_no = _IO_MAX + num;
+  snprintf (msg.msg_data, 254, "client %d requesting reply.", getpid ());
+
+  printf ("client: msg_no: _IO_MAX + %d\n", num);
+  fflush (stdout);
+
+  i = 0;
+loop:
+  /* Send the data to the server and get a reply */
+  msg.msg_no = _IO_MAX + num;
+  ret = MsgSend (fd, &msg, sizeof (msg), msg_reply, 255);
+  if (ret == -1)
+    {
+      fprintf (stderr, "Unable to MsgSend() to server: %s\n",
+	       strerror (errno));
+      return EXIT_FAILURE;
+    }
+  if (num == 1)
+    {
+      float tmp[12];
+      memcpy (tmp, msg_reply, sizeof (float) * 12);
+      printf ("client: msg_reply: %7.3f %7.3f %7.3f %7.3f %7.3f %7.3f\n",
+	      tmp[0], tmp[1], tmp[2], tmp[3], tmp[4], tmp[5]);
+      printf ("                   %7.3f %7.3f %7.3f %7.3f %7.3f %7.3f\n",
+	      tmp[6], tmp[7], tmp[8], tmp[9], tmp[10], tmp[11]);
+    }
+  else
+    {
+      printf ("client: msg_reply:\n%s\n", msg_reply);
+    }
+
+  if (num > 1)
+    num--;
+
+  usleep (100000);
+  if ((i % 20) == 0)
+    {
+      num = 4;
+    }
+
+
+  if (i++ < 100000)
+    goto loop;
+
+  close (fd);
+
+  return EXIT_SUCCESS;
+}

--- a/hironx_ros_bridge/robot/dynpick/sample_dynpick.c
+++ b/hironx_ros_bridge/robot/dynpick/sample_dynpick.c
@@ -44,7 +44,7 @@ main (int argc, char **argv)
   int num;
   char msg_reply[255];
   int i;
-  struct timeval c0, c1;
+  struct timeval c0, c1, l0, l1;
 
   printf ("\x1b[2J");
   printf ("\x1b[0;0H");
@@ -82,6 +82,7 @@ main (int argc, char **argv)
 
   i = 0;
 loop:
+  gettimeofday(&l0, NULL);
   /* Send the data to the server and get a reply */
   msg.msg_no = _IO_MAX + num;
   gettimeofday(&c0, NULL);
@@ -119,6 +120,8 @@ loop:
     }
 
   if (i++ < 100000)
+    gettimeofday(&l1, NULL);
+    printf ("Loop took %7.3f msec\n", DELTA_SEC(l0, l1)*1000);
     goto loop;
 
   close (fd);

--- a/hironx_ros_bridge/robot/dynpick/test-com.c
+++ b/hironx_ros_bridge/robot/dynpick/test-com.c
@@ -96,7 +96,7 @@ int main()
 start :
    // Open COM port
    printf("Enter COM port > ");
-   //scanf("%d", &comNo);
+   scanf("%d", &comNo);
    comNo = 1;
    sprintf(devname_out, "/dev/serusb%d", comNo);
    printf("Open %s for output\n", devname_out);
@@ -159,6 +159,7 @@ start :
 #define DATA_LENGTH 27
 	len = 0;
 	bzero(str, 27);
+        int clk_read_start = clock();
 	while ( len < DATA_LENGTH ) 
 	  {
 	     n = read(fd, str+len, DATA_LENGTH-len);
@@ -171,9 +172,11 @@ start :
 	       {
 		  char *pmesg = strerror(errno);
 		  fprintf (stderr, "failed to read data (%d): %s (%d)\n", n, pmesg, errno);
-		  goto loop_exit;
+		  usleep(10000);
+		  //goto loop_exit;
 	       }
 	  }
+	int clk_read_end = clock();
 	//goto skip;
 loop_exit :
 	  {
@@ -182,7 +185,7 @@ loop_exit :
 	       {
 		  fprintf(stderr, "%02x:", 0x0000ff & str[i]);
 	       }
-	     fprintf(stderr, "\n");
+	     fprintf(stderr, " %7.3f [msec]\n", ((float)(clk_read_end - clk_read_start))/(CLOCKS_PER_SEC / 1000) );
 	  }
 	
 	     
@@ -200,7 +203,7 @@ loop_exit :
 	num++;
 
 skip :
-	if (clk >= 100) //10000
+	if (clk >= 10000) //10000
 	  break;
 
 	// Dsiaply Console

--- a/hironx_ros_bridge/robot/dynpick/test-com.c
+++ b/hironx_ros_bridge/robot/dynpick/test-com.c
@@ -76,8 +76,7 @@ int main()
 {
    int			status;
    //FILE			*fd;
-   int			fd_in;
-   int			fd_out;
+   int			fd;
    char			fname[64];
    char			devname_in[64];
    char			devname_out[64];	   
@@ -92,30 +91,18 @@ int main()
 
    
    //fd = NULL;
-   fd_in = -1;
-   fd_out = -1;   
+   fd = -1;   
 
 start :
    // Open COM port
    printf("Enter COM port > ");
    //scanf("%d", &comNo);
    comNo = 1;
-#if 1
    sprintf(devname_out, "/dev/serusb%d", comNo);
    printf("Open %s for output\n", devname_out);
-   fd_in = fd_out = open(devname_out, O_RDWR | O_NOCTTY | O_NONBLOCK );
-   //fd_in = fd_out = open(devname_out, O_RDWR);
-#else
-   sprintf(devname_out, "/dev/ser%d", comNo);
-   printf("Open %s for output\n", devname_out);
-   fd_out = open(devname_out, O_WRONLY | O_NOCTTY | O_NONBLOCK );
+   fd = open(devname_out, O_RDWR | O_NOCTTY | O_NONBLOCK );
 
-   sprintf(devname_in, "/dev/ser%d", comNo+1);
-   printf("Open %s for input\n", devname_in);
-   fd_in = open(devname_in, O_RDONLY | O_NOCTTY | O_NONBLOCK );
-#endif   
-
-   if (fd_in < 0 || fd_out < 0)
+   if (fd < 0 || fd < 0)
      goto over;
 
    // Get Sampling Frequency
@@ -133,11 +120,10 @@ start :
    //if (!fd)
    //	goto over;
 
-   slogf(0, _SLOG_INFO, "Started  input: %s fd = %d\n", devname_in, fd_in);
-   slogf(0, _SLOG_INFO, "        output: %s fd = %d\n", devname_out, fd_out);	   
+   slogf(0, _SLOG_INFO, "Started  input: %s fd = %d\n", devname_in, fd);
+   slogf(0, _SLOG_INFO, "        output: %s fd = %d\n", devname_out, fd);	   
    // Set Commport Settings
-   SetComAttr(fd_in);
-   SetComAttr(fd_out);
+   SetComAttr(fd);
 
    // Read Data
    printf("=== record data ===\n");
@@ -147,9 +133,9 @@ start :
    num = 0;
 
    // Data Requests
-   n = write(fd_out, "R", 1);
-   tcdrain(fd_out);
-   printf("write data %d\n", n);
+   n = write(fd, "R", 1);
+   tcdrain(fd);
+   printf("write data (ret %d)\n", n);
 
    while (true)
      {
@@ -165,9 +151,9 @@ start :
 	  }
 	
 	// Data Request
-	n = write(fd_out, "R", 1);
-	tcdrain(fd_out);
-	printf("write data %d\n", n);
+	n = write(fd, "R", 1);
+	tcdrain(fd);
+	printf("write data (ret %d)\n", n);
 
 	// Get Singale data
 #define DATA_LENGTH 27
@@ -175,8 +161,8 @@ start :
 	bzero(str, 27);
 	while ( len < DATA_LENGTH ) 
 	  {
-	     n = read(fd_in, str+len, DATA_LENGTH-len);
-	     printf("read data %d (%d)\n", n, len);
+	     n = read(fd, str+len, DATA_LENGTH-len);
+	     printf("read data (ret %d, %d bytes read))\n", n, len+n);
 	     if ( n > 0 ) 
 	       {
 		  len += n;
@@ -220,33 +206,19 @@ skip :
 	// Dsiaply Console
 	if (clk >= clkb2 + 1000)
 	  {
-#if 0
 	     printf(str);
 	     if (kbhit() &&
 		 getchar() == '.')
 	       break;
-#endif
 	     clkb2 = clk / 1000 * 1000;
 	  }
      }
 
 over :
-#if 0
-   if (fd)
+   if (fd >= 0)
      {
-	fclose(fd);
-	fd = NULL;
-     }
-#endif
-   if (fd_in >= 0)
-     {
-	close(fd_in);
-	fd_in = -1;
-     }
-   if (fd_out >= 0)
-     {
-	close(fd_out);
-	fd_out = -1;
+	close(fd);
+	fd = -1;
      }
 
    printf ("=== num = %d ===\n", num);

--- a/hironx_ros_bridge/robot/dynpick/test-com.c
+++ b/hironx_ros_bridge/robot/dynpick/test-com.c
@@ -1,0 +1,496 @@
+// test-com.c
+#define 	DEBUGSS	0
+
+#include	<stdio.h>
+#include	<fcntl.h>
+#include	<errno.h>
+#include	<time.h>
+#include	<termios.h>
+#include	<string.h>
+#include <unistd.h>
+#include <math.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/select.h>
+#include <sys/slog.h>
+
+#define true		1
+#define false		0
+
+int kbhit(void)
+{
+   
+       struct termios oldt, newt;
+       int ch;
+       int oldf;
+   
+       tcgetattr(STDIN_FILENO, &oldt);
+       newt = oldt;
+       newt.c_lflag &= ~(ICANON | ECHO);
+       tcsetattr(STDIN_FILENO, TCSANOW, &newt);
+       oldf = fcntl(STDIN_FILENO, F_GETFL, 0);
+       fcntl(STDIN_FILENO, F_SETFL, oldf | O_NONBLOCK);
+   
+       ch = getchar();
+   
+       tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+       fcntl(STDIN_FILENO, F_SETFL, oldf);
+   
+       if (ch != EOF) 
+     {
+	
+	        ungetc(ch, stdin);
+	        return 1;
+     }
+   
+   
+       return 0;
+}
+
+#define cfsetspeed(term, baudrate)\
+   cfsetispeed(term, baudrate);\
+   cfsetospeed(term, baudrate);
+
+int com_write(int fd, const char* msg) 
+{
+  // IO is currently non-blocking. This is what we want for the more common read case.
+   int origflags = fcntl(fd,F_GETFL,0);
+   fcntl(fd, F_SETFL, origflags & ~O_NONBLOCK); // @todo can we make this all work in non-blocking?
+   ssize_t len = strlen(msg);
+   ssize_t retval = write(fd, msg, len);
+   int fputserrno = errno;
+   fcntl(fd, F_SETFL, origflags | O_NONBLOCK);
+   errno = fputserrno; // Don't want to see the fcntl errno below.
+     
+   if (retval != -1)
+     {
+	    return retval;
+     }
+   printf("fputs fialed %d: %s", errno, strerror(errno));
+   return -1;
+}
+
+
+
+int main() 
+{
+   int			status;
+   //FILE			*fd;
+   int			fd_in;
+   int			fd_out;
+   char			fname[64];
+   char			devname_in[64];
+   char			devname_out[64];	   
+   char			str[256];
+   unsigned short	data[6];
+   int			comNo;
+   int			tick;
+   int			clk, clkb, clkb2, clk0;
+   int			tw;
+   int			num;
+   int			n, len;
+
+   
+   //fd = NULL;
+   fd_in = -1;
+   fd_out = -1;   
+
+start :
+   // Open COM port
+   printf("Enter COM port > ");
+   //scanf("%d", &comNo);
+   comNo = 1;
+#if 1
+   sprintf(devname_out, "/dev/serusb%d", comNo);
+   printf("Open %s for output\n", devname_out);
+   fd_in = fd_out = open(devname_out, O_RDWR | O_NOCTTY | O_NONBLOCK );
+   //fd_in = fd_out = open(devname_out, O_RDWR);
+#else
+   sprintf(devname_out, "/dev/ser%d", comNo);
+   printf("Open %s for output\n", devname_out);
+   fd_out = open(devname_out, O_WRONLY | O_NOCTTY | O_NONBLOCK );
+
+   sprintf(devname_in, "/dev/ser%d", comNo+1);
+   printf("Open %s for input\n", devname_in);
+   fd_in = open(devname_in, O_RDONLY | O_NOCTTY | O_NONBLOCK );
+#endif   
+
+   if (fd_in < 0 || fd_out < 0)
+     goto over;
+
+   // Get Sampling Frequency
+   tw = 16;
+   printf("Enter sampling time (ms) > ");
+   fflush(stdout);
+   //scanf("%d", &tw);
+   printf("Sampling time = %d ms\n", tw);
+
+   printf("Enter File name > ");
+   fflush(stdout);
+   //scanf("%s", fname);
+   //fd = fopen(fname, "w");
+   //fd = fopen("test.txt", "w");
+   //if (!fd)
+   //	goto over;
+
+   slogf(0, _SLOG_INFO, "Started  input: %s fd = %d\n", devname_in, fd_in);
+   slogf(0, _SLOG_INFO, "        output: %s fd = %d\n", devname_out, fd_out);	   
+   // Set Commport Settings
+   SetComAttr(fd_in);
+   SetComAttr(fd_out);
+
+   // Read Data
+   printf("=== record data ===\n");
+   clk0 = clock() / (CLOCKS_PER_SEC / 1000);
+   clkb = 0;
+   clkb2 = 0;
+   num = 0;
+
+   // Data Requests
+   n = write(fd_out, "R", 1);
+   tcdrain(fd_out);
+   printf("write data %d\n", n);
+
+   while (true)
+     {
+	// Wait for Sampling rate
+	while (true)
+	  {
+	     clk = clock() / (CLOCKS_PER_SEC / 1000) - clk0;
+	     if (clk >= clkb + tw)
+	       {
+		  clkb = clk / tw * tw;
+		  break;
+	       }
+	  }
+	
+	// Data Request
+	n = write(fd_out, "R", 1);
+	tcdrain(fd_out);
+	printf("write data %d\n", n);
+
+	// Get Singale data
+#define DATA_LENGTH 27
+	len = 0;
+	bzero(str, 27);
+	while ( len < DATA_LENGTH ) 
+	  {
+	     n = read(fd_in, str+len, DATA_LENGTH-len);
+	     printf("read data %d (%d)\n", n, len);
+	     if ( n > 0 ) 
+	       {
+		  len += n;
+	       }
+	     else
+	       {
+		  char *pmesg = strerror(errno);
+		  fprintf (stderr, "failed to read data (%d): %s (%d)\n", n, pmesg, errno);
+		  goto loop_exit;
+	       }
+	  }
+	//goto skip;
+loop_exit :
+	  {
+	     int i;
+	     for(i = 0; i < DATA_LENGTH;i++)
+	       {
+		  fprintf(stderr, "%02x:", 0x0000ff & str[i]);
+	       }
+	     fprintf(stderr, "\n");
+	  }
+	
+	     
+	     
+
+	sscanf(str, "%1d%4hx%4hx%4hx%4hx%4hx%4hx",
+	       &tick, &data[0], &data[1], &data[2], &data[3], &data[4], &data[5]);
+
+	sprintf(str, "%05d,%d,%05d,%05d,%05d,%05d,%05d,%05d\n",
+		clk / tw * tw, tick,
+		data[0], data[1], data[2], data[3], data[4], data[5]);
+
+	fprintf(stderr, str);	
+	//fprintf(fd, str);
+	num++;
+
+skip :
+	if (clk >= 100) //10000
+	  break;
+
+	// Dsiaply Console
+	if (clk >= clkb2 + 1000)
+	  {
+#if 0
+	     printf(str);
+	     if (kbhit() &&
+		 getchar() == '.')
+	       break;
+#endif
+	     clkb2 = clk / 1000 * 1000;
+	  }
+     }
+
+over :
+#if 0
+   if (fd)
+     {
+	fclose(fd);
+	fd = NULL;
+     }
+#endif
+   if (fd_in >= 0)
+     {
+	close(fd_in);
+	fd_in = -1;
+     }
+   if (fd_out >= 0)
+     {
+	close(fd_out);
+	fd_out = -1;
+     }
+
+   printf ("=== num = %d ===\n", num);
+
+   printf("exit (y / n) ? > ");
+   fflush(stdout);
+   exit(0);//scanf("%s", str);
+   if (str[0] == 'y')
+     {
+//		exit(0);
+     }
+   else
+     {
+	goto start;
+     }
+}
+
+
+void clear_packet(int fd)
+{
+   
+   // clear existing packet
+   int oldf = fcntl(fd, F_GETFL, 0);
+   fcntl(fd, F_SETFL, oldf | O_NONBLOCK);
+   unsigned char c;
+   while ( read(fd, &c, 1) != EOF );
+   fcntl(fd, F_SETFL, oldf);
+}
+
+//#define  B921600  B57600
+#define   B921600 0010007
+
+int SetComAttr2(int fd)
+{
+   // Settings for USB?
+   struct termios newtio;
+   tcgetattr(fd, &newtio);
+   memset (&newtio.c_cc, 0, sizeof (newtio.c_cc));
+   newtio.c_cflag |= CS8 | CLOCAL | CREAD;
+   //newtio.c_cflag = B921600 | CS8 | CLOCAL | CREAD;
+   newtio.c_cflag &= ~(IHFLOW | OHFLOW);
+   newtio.c_iflag = IGNPAR;
+   newtio.c_oflag = 0;
+   newtio.c_lflag = 0;//ICANON;
+   //newtio.c_lflag |= IEXTEN; // QNX?
+   //newtio.c_lflag = 0;   
+		
+   newtio.c_cc[VMIN] = 1;
+   newtio.c_cc[VTIME] = 2;   
+   newtio.c_cc[VEOF] = 4;     /* Ctrl-d */
+
+   //printf("speed = %04o %d\n", B9600, B9600);
+   //printf("speed = %04o %d\n", B115200, B9600);
+   //printf("speed = %04o %d\n", B921600, B9600);   
+#if 0
+   int n;
+   n = cfsetspeed(&newtio, 921600L);
+   //n = cfsetspeed(&newtio, 115200);
+   if (n<0)
+     {
+	char *pmesg = strerror(errno);
+	fprintf (stderr, "failed to cfsetspeed(): %s\n", pmesg);
+	exit(-1);
+     }
+#endif   
+   // activate new settings
+   tcflush (fd, TCIFLUSH);
+   if (tcsetattr (fd, TCSANOW, &newtio) < 0) 
+     {
+	printf("can not set attr");
+	exit(-1);
+     }
+		
+   sleep(1);
+		
+   int retval = tcflush(fd, TCIOFLUSH);
+   if (retval != 0) 
+     {
+	printf("tcflush failed\n");
+     }
+}
+
+
+
+int SetComAttr4(int fdc)
+{
+
+   int n;
+
+   struct termios term;
+   
+   n = tcgetattr(fdc, &term);
+   if (n < 0)
+     {
+	char *pmesg = strerror(errno);
+	fprintf (stderr, "failed to tcgetattr(): %s\n", pmesg);
+	goto over;
+     }
+   
+   bzero(&term, sizeof(term));
+
+   //term.c_cflag = B115200 | CS8 | CLOCAL | CREAD;
+   term.c_cflag = CS8 | CLOCAL | CREAD;
+#if 1
+   //n = cfsetspeed(&term, 115200L);
+   //n = cfsetspeed(&term, 230400L);      
+   //n = cfsetspeed(&term, 460800L);         
+   n = cfsetspeed(&term, 921600L);
+   //n = cfsetspeed(&term, 115200);
+   //n = cfsetspeed(&term, 19200);   
+   if (n<0)
+     {
+		
+	char *pmesg = strerror(errno);
+	fprintf (stderr, "failed to cfsetspeed(): %s\n", pmesg);
+	goto over;
+     }
+#endif
+   term.c_iflag = IGNPAR;
+   term.c_oflag = 0;
+   term.c_lflag = 0;/*ICANON;*/
+   //term.c_lflag = 0;/*ICANON;*/
+   term.c_lflag |= IEXTEN; // QNX?
+    
+   term.c_cc[VINTR]    = 0;     /* Ctrl-c */ 
+   term.c_cc[VQUIT]    = 0;     /* Ctrl-? */
+   term.c_cc[VERASE]   = 0;     /* del */
+   term.c_cc[VKILL]    = 0;     /* @ */
+   term.c_cc[VEOF]     = 4;     /* Ctrl-d */
+   term.c_cc[VTIME]    = 0;
+   term.c_cc[VMIN]     = 0;
+   //term.c_cc[VSWTC]    = 0;     /* '?0' */
+   term.c_cc[VSTART]   = 0;     /* Ctrl-q */ 
+   term.c_cc[VSTOP]    = 0;     /* Ctrl-s */
+   term.c_cc[VSUSP]    = 0;     /* Ctrl-z */
+   term.c_cc[VEOL]     = 0;     /* '?0' */
+   term.c_cc[VREPRINT] = 0;     /* Ctrl-r */
+   term.c_cc[VDISCARD] = 0;     /* Ctrl-u */
+   term.c_cc[VWERASE]  = 0;     /* Ctrl-w */
+   term.c_cc[VLNEXT]   = 0;     /* Ctrl-v */
+   term.c_cc[VEOL2]    = 0;     /* '?0' */
+   
+#ifdef __QNX__
+   term.c_cflag &= ~PARENB;           // disable parity check
+   term.c_cflag &= ~CSTOPB;           // 1 stop bit
+   term.c_cflag &= ~(IHFLOW | OHFLOW);
+   // settings for qnx
+   term.c_cc[VMIN] = 1;
+   term.c_cc[VTIME] = 0;
+#endif
+
+   //tcflush(fdc, TCIFLUSH);
+   n = tcsetattr(fdc, TCSANOW, &term);
+   if (n<0) 
+     {
+		
+	char *pmesg = strerror(errno);
+	fprintf (stderr, "failed to tcsetattr(): %s\n", pmesg);
+	goto over;
+     }
+
+   over:
+
+   sleep(2);
+   return (n);
+}
+
+
+int SetComAttr(int fdc)
+	{
+	if (fdc < 0)
+	     {
+		char *pmesg = strerror(errno);
+		fprintf (stderr, "failed to open : %s\n", pmesg);
+		goto over;
+	     }
+	   
+	   
+	struct termios term;
+	int res = tcgetattr(fdc, &term);
+	if (res<0)
+	     {
+		char *pmesg = strerror(errno);
+		fprintf (stderr, "failed to tcgetattr(): %s\n", pmesg);
+		goto over;
+	     }
+	 cfmakeraw(&term);
+	 res = cfsetspeed(&term, 921600);
+//	 res = cfsetspeed(&term, 230400);
+	 if (res<0) 
+	     {
+		
+		char *pmesg = strerror(errno);
+		fprintf (stderr, "failed to cfsetspeed(): %s\n", pmesg);
+		goto over;
+	     }
+
+	 // settings for qnx
+	 term.c_iflag |= IGNPAR;            // Ignore characters with parity errors
+	 term.c_cflag |= (CLOCAL | CREAD);  // needed for QNX 6.3.2
+	 term.c_cflag &= ~PARENB;           // disable parity check
+	 term.c_cflag |= CS8;               // 8 data bit
+	 term.c_cflag &= ~CSTOPB;           // 1 stop bit
+	 //term.c_lflag = IEXTEN;
+	 term.c_oflag = 0; ///added
+	 term.c_lflag &= ~(ECHO | ECHOCTL | ECHONL);  // disable ECHO
+	   
+	 //
+	 term.c_iflag &= ~INPCK;
+
+	 // settings for dynpick
+	   term.c_cc[VINTR]    = 0;     /* Ctrl-c */
+	   term.c_cc[VQUIT]    = 0;     /* Ctrl-? */	   term.c_cc[VERASE]   = 0;     /* del */
+	   term.c_cc[VKILL]    = 0;     /* @ */
+	   term.c_cc[VEOF]     = 4;     /* Ctrl-d */
+	   term.c_cc[VTIME]    = 0;
+	   term.c_cc[VMIN]     = 0;
+	   //term.c_cc[VSWTC]    = 0;     /* '?0' */
+	   term.c_cc[VSTART]   = 0;     /* Ctrl-q */ 
+	   term.c_cc[VSTOP]    = 0;     /* Ctrl-s */
+	   term.c_cc[VSUSP]    = 0;     /* Ctrl-z */
+	   term.c_cc[VEOL]     = 0;     /* '?0' */
+	   term.c_cc[VREPRINT] = 0;     /* Ctrl-r */
+	   term.c_cc[VDISCARD] = 0;     /* Ctrl-u */
+	   term.c_cc[VWERASE]  = 0;     /* Ctrl-w */
+	   term.c_cc[VLNEXT]   = 0;     /* Ctrl-v */
+	   term.c_cc[VEOL2]    = 0;     /* '?0' */
+#ifdef __QNX__
+	 term.c_cflag &= ~(IHFLOW | OHFLOW);
+#endif
+
+	 // settings for qnx
+	 term.c_cc[VMIN] = 100;
+	 term.c_cc[VTIME] = 0;
+
+	 res = tcsetattr(fdc, TCSANOW, &term);
+	 if (res<0) 
+	     {
+		char *pmesg = strerror(errno);
+		fprintf (stderr, "failed to tcsetattr(): %s\n", pmesg);
+		goto over;
+	     }
+
+over :
+	return (res);
+	}
+

--- a/hironx_ros_bridge/robot/dynpick/test-com.c
+++ b/hironx_ros_bridge/robot/dynpick/test-com.c
@@ -13,6 +13,7 @@
 #include <sys/stat.h>
 #include <sys/select.h>
 #include <sys/slog.h>
+#include <sys/time.h>
 
 #define true		1
 #define false		0
@@ -159,7 +160,8 @@ start :
 #define DATA_LENGTH 27
 	len = 0;
 	bzero(str, 27);
-        int clk_read_start = clock();
+        struct timeval tm0, tm1;
+	gettimeofday(&tm0, NULL);
 	while ( len < DATA_LENGTH ) 
 	  {
 	     n = read(fd, str+len, DATA_LENGTH-len);
@@ -176,7 +178,7 @@ start :
 		  //goto loop_exit;
 	       }
 	  }
-	int clk_read_end = clock();
+	gettimeofday(&tm1, NULL);
 	//goto skip;
 loop_exit :
 	  {
@@ -185,7 +187,8 @@ loop_exit :
 	       {
 		  fprintf(stderr, "%02x:", 0x0000ff & str[i]);
 	       }
-	     fprintf(stderr, " %7.3f [msec]\n", ((float)(clk_read_end - clk_read_start))/(CLOCKS_PER_SEC / 1000) );
+#define DELTA_SEC(start, end) (end.tv_sec - start.tv_sec + (end.tv_usec - start.tv_usec)/1e6)
+	     fprintf(stderr, " %7.3f [msec]\n", DELTA_SEC(tm0, tm1)*1000 );
 	  }
 	
 	     
@@ -203,7 +206,7 @@ loop_exit :
 	num++;
 
 skip :
-	if (clk >= 10000) //10000
+	if (clk >= 10000)
 	  break;
 
 	// Dsiaply Console
@@ -454,8 +457,8 @@ int SetComAttr(int fdc)
 #endif
 
 	 // settings for qnx
-	 term.c_cc[VMIN] = 100;
-	 term.c_cc[VTIME] = 0;
+	 term.c_cc[VMIN] = 0;
+	 term.c_cc[VTIME] = 2;
 
 	 res = tcsetattr(fdc, TCSANOW, &term);
 	 if (res<0) 

--- a/hironx_ros_bridge/robot/dynpick/test-com.c
+++ b/hironx_ros_bridge/robot/dynpick/test-com.c
@@ -399,7 +399,7 @@ int SetComAttr(int fdc) {
 	term.c_cc[VKILL] = 0; /* @ */
 	term.c_cc[VEOF] = 4; /* Ctrl-d */
 	term.c_cc[VTIME] = 0;
-	term.c_cc[VMIN] = 0;
+	term.c_cc[VMIN] = 1;
 	//term.c_cc[VSWTC]    = 0;     /* '?0' */
 	term.c_cc[VSTART] = 0; /* Ctrl-q */
 	term.c_cc[VSTOP] = 0; /* Ctrl-s */

--- a/hironx_ros_bridge/robot/dynpick/test-com.c
+++ b/hironx_ros_bridge/robot/dynpick/test-com.c
@@ -18,457 +18,413 @@
 #define true		1
 #define false		0
 
-int kbhit(void)
-{
-   
-       struct termios oldt, newt;
-       int ch;
-       int oldf;
-   
-       tcgetattr(STDIN_FILENO, &oldt);
-       newt = oldt;
-       newt.c_lflag &= ~(ICANON | ECHO);
-       tcsetattr(STDIN_FILENO, TCSANOW, &newt);
-       oldf = fcntl(STDIN_FILENO, F_GETFL, 0);
-       fcntl(STDIN_FILENO, F_SETFL, oldf | O_NONBLOCK);
-   
-       ch = getchar();
-   
-       tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-       fcntl(STDIN_FILENO, F_SETFL, oldf);
-   
-       if (ch != EOF) 
-     {
-	
-	        ungetc(ch, stdin);
-	        return 1;
-     }
-   
-   
-       return 0;
+int kbhit(void) {
+
+	struct termios oldt, newt;
+	int ch;
+	int oldf;
+
+	tcgetattr(STDIN_FILENO, &oldt);
+	newt = oldt;
+	newt.c_lflag &= ~(ICANON | ECHO);
+	tcsetattr(STDIN_FILENO, TCSANOW, &newt);
+	oldf = fcntl(STDIN_FILENO, F_GETFL, 0);
+	fcntl(STDIN_FILENO, F_SETFL, oldf | O_NONBLOCK);
+
+	ch = getchar();
+
+	tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+	fcntl(STDIN_FILENO, F_SETFL, oldf);
+
+	if (ch != EOF) {
+
+		ungetc(ch, stdin);
+		return 1;
+	}
+
+	return 0;
 }
 
 #define cfsetspeed(term, baudrate)\
    cfsetispeed(term, baudrate);\
    cfsetospeed(term, baudrate);
 
-int com_write(int fd, const char* msg) 
-{
-  // IO is currently non-blocking. This is what we want for the more common read case.
-   int origflags = fcntl(fd,F_GETFL,0);
-   fcntl(fd, F_SETFL, origflags & ~O_NONBLOCK); // @todo can we make this all work in non-blocking?
-   ssize_t len = strlen(msg);
-   ssize_t retval = write(fd, msg, len);
-   int fputserrno = errno;
-   fcntl(fd, F_SETFL, origflags | O_NONBLOCK);
-   errno = fputserrno; // Don't want to see the fcntl errno below.
-     
-   if (retval != -1)
-     {
-	    return retval;
-     }
-   printf("fputs fialed %d: %s", errno, strerror(errno));
-   return -1;
+int com_write(int fd, const char* msg) {
+	// IO is currently non-blocking. This is what we want for the more common read case.
+	int origflags = fcntl(fd, F_GETFL, 0);
+	fcntl(fd, F_SETFL, origflags & ~O_NONBLOCK); // @todo can we make this all work in non-blocking?
+	ssize_t len = strlen(msg);
+	ssize_t retval = write(fd, msg, len);
+	int fputserrno = errno;
+	fcntl(fd, F_SETFL, origflags | O_NONBLOCK);
+	errno = fputserrno; // Don't want to see the fcntl errno below.
+
+	if (retval != -1) {
+		return retval;
+	}
+	printf("fputs fialed %d: %s", errno, strerror(errno));
+	return -1;
 }
 
+int main() {
+	int status;
+	//FILE			*fd;
+	int fd;
+	char fname[64];
+	char devname_in[64];
+	char devname_out[64];
+	char str[256];
+	unsigned short data[6];
+	int comNo;
+	int tick;
+	int clk, clkb, clkb2, clk0;
+	int tw;
+	int num;
+	int n, len;
 
+	//fd = NULL;
+	fd = -1;
 
-int main() 
-{
-   int			status;
-   //FILE			*fd;
-   int			fd;
-   char			fname[64];
-   char			devname_in[64];
-   char			devname_out[64];	   
-   char			str[256];
-   unsigned short	data[6];
-   int			comNo;
-   int			tick;
-   int			clk, clkb, clkb2, clk0;
-   int			tw;
-   int			num;
-   int			n, len;
+	start:
+	// Open COM port
+	printf("Enter COM port > ");
+	scanf("%d", &comNo);
+	comNo = 1;
+	sprintf(devname_out, "/dev/serusb%d", comNo);
+	printf("Open %s for output\n", devname_out);
+	fd = open(devname_out, O_RDWR | O_NOCTTY | O_NONBLOCK);
 
-   
-   //fd = NULL;
-   fd = -1;   
+	if (fd < 0 || fd < 0)
+		goto over;
 
-start :
-   // Open COM port
-   printf("Enter COM port > ");
-   scanf("%d", &comNo);
-   comNo = 1;
-   sprintf(devname_out, "/dev/serusb%d", comNo);
-   printf("Open %s for output\n", devname_out);
-   fd = open(devname_out, O_RDWR | O_NOCTTY | O_NONBLOCK );
+	// Get Sampling Frequency
+	tw = 16;
+	printf("Enter sampling time (ms) > ");
+	fflush(stdout);
+	//scanf("%d", &tw);
+	printf("Sampling time = %d ms\n", tw);
 
-   if (fd < 0 || fd < 0)
-     goto over;
+	printf("Enter File name > ");
+	fflush(stdout);
+	//scanf("%s", fname);
+	//fd = fopen(fname, "w");
+	//fd = fopen("test.txt", "w");
+	//if (!fd)
+	//	goto over;
 
-   // Get Sampling Frequency
-   tw = 16;
-   printf("Enter sampling time (ms) > ");
-   fflush(stdout);
-   //scanf("%d", &tw);
-   printf("Sampling time = %d ms\n", tw);
+	slogf(0, _SLOG_INFO, "Started  input: %s fd = %d\n", devname_in, fd);
+	slogf(0, _SLOG_INFO, "        output: %s fd = %d\n", devname_out, fd);
+	// Set Commport Settings
+	SetComAttr(fd);
 
-   printf("Enter File name > ");
-   fflush(stdout);
-   //scanf("%s", fname);
-   //fd = fopen(fname, "w");
-   //fd = fopen("test.txt", "w");
-   //if (!fd)
-   //	goto over;
+	// Read Data
+	printf("=== record data ===\n");
+	clk0 = clock() / (CLOCKS_PER_SEC / 1000);
+	clkb = 0;
+	clkb2 = 0;
+	num = 0;
 
-   slogf(0, _SLOG_INFO, "Started  input: %s fd = %d\n", devname_in, fd);
-   slogf(0, _SLOG_INFO, "        output: %s fd = %d\n", devname_out, fd);	   
-   // Set Commport Settings
-   SetComAttr(fd);
-
-   // Read Data
-   printf("=== record data ===\n");
-   clk0 = clock() / (CLOCKS_PER_SEC / 1000);
-   clkb = 0;
-   clkb2 = 0;
-   num = 0;
-
-   // Data Requests
-   n = write(fd, "R", 1);
-   tcdrain(fd);
-   printf("write data (ret %d)\n", n);
-
-   while (true)
-     {
-	// Wait for Sampling rate
-	while (true)
-	  {
-	     clk = clock() / (CLOCKS_PER_SEC / 1000) - clk0;
-	     if (clk >= clkb + tw)
-	       {
-		  clkb = clk / tw * tw;
-		  break;
-	       }
-	  }
-	
-	// Data Request
+	// Data Requests
 	n = write(fd, "R", 1);
 	tcdrain(fd);
 	printf("write data (ret %d)\n", n);
 
-	// Get Singale data
+	while (true) {
+		// Wait for Sampling rate
+		while (true) {
+			clk = clock() / (CLOCKS_PER_SEC / 1000) - clk0;
+			if (clk >= clkb + tw) {
+				clkb = clk / tw * tw;
+				break;
+			}
+		}
+
+		// Data Request
+		n = write(fd, "R", 1);
+		tcdrain(fd);
+		printf("write data (ret %d)\n", n);
+
+		// Get Singale data
 #define DATA_LENGTH 27
-	len = 0;
-	bzero(str, 27);
-        struct timeval tm0, tm1;
-	gettimeofday(&tm0, NULL);
-	while ( len < DATA_LENGTH ) 
-	  {
-	     n = read(fd, str+len, DATA_LENGTH-len);
-	     printf("read data (ret %d, %d bytes read))\n", n, len+n);
-	     if ( n > 0 ) 
-	       {
-		  len += n;
-	       }
-	     else
-	       {
-		  char *pmesg = strerror(errno);
-		  fprintf (stderr, "failed to read data (%d): %s (%d)\n", n, pmesg, errno);
-		  usleep(10000);
-		  //goto loop_exit;
-	       }
-	  }
-	gettimeofday(&tm1, NULL);
-	//goto skip;
-loop_exit :
-	  {
-	     int i;
-	     for(i = 0; i < DATA_LENGTH;i++)
-	       {
-		  fprintf(stderr, "%02x:", 0x0000ff & str[i]);
-	       }
+		len = 0;
+		bzero(str, 27);
+		struct timeval tm0, tm1;
+		gettimeofday(&tm0, NULL);
+		while (len < DATA_LENGTH) {
+			n = read(fd, str + len, DATA_LENGTH - len);
+			printf("read data (ret %d, %d bytes read))\n", n, len + n);
+			if (n > 0) {
+				len += n;
+			} else {
+				char *pmesg = strerror(errno);
+				fprintf(stderr, "failed to read data (%d): %s (%d)\n", n, pmesg,
+						errno);
+				usleep(10000);
+				//goto loop_exit;
+			}
+		}
+		gettimeofday(&tm1, NULL);
+		//goto skip;
+		loop_exit: {
+			int i;
+			for (i = 0; i < DATA_LENGTH; i++) {
+				fprintf(stderr, "%02x:", 0x0000ff & str[i]);
+			}
 #define DELTA_SEC(start, end) (end.tv_sec - start.tv_sec + (end.tv_usec - start.tv_usec)/1e6)
-	     fprintf(stderr, " %7.3f [msec]\n", DELTA_SEC(tm0, tm1)*1000 );
-	  }
-	
-	     
-	     
+			fprintf(stderr, " %7.3f [msec]\n", DELTA_SEC(tm0, tm1) * 1000);
+		}
 
-	sscanf(str, "%1d%4hx%4hx%4hx%4hx%4hx%4hx",
-	       &tick, &data[0], &data[1], &data[2], &data[3], &data[4], &data[5]);
+		sscanf(str, "%1d%4hx%4hx%4hx%4hx%4hx%4hx", &tick, &data[0], &data[1],
+				&data[2], &data[3], &data[4], &data[5]);
 
-	sprintf(str, "%05d,%d,%05d,%05d,%05d,%05d,%05d,%05d\n",
-		clk / tw * tw, tick,
-		data[0], data[1], data[2], data[3], data[4], data[5]);
+		sprintf(str, "%05d,%d,%05d,%05d,%05d,%05d,%05d,%05d\n", clk / tw * tw,
+				tick, data[0], data[1], data[2], data[3], data[4], data[5]);
 
-	fprintf(stderr, str);	
-	//fprintf(fd, str);
-	num++;
+		fprintf(stderr, str);
+		//fprintf(fd, str);
+		num++;
 
-skip :
-	if (clk >= 10000)
-	  break;
+		skip: if (clk >= 10000)
+			break;
 
-	// Dsiaply Console
-	if (clk >= clkb2 + 1000)
-	  {
-	     printf(str);
-	     if (kbhit() &&
-		 getchar() == '.')
-	       break;
-	     clkb2 = clk / 1000 * 1000;
-	  }
-     }
+		// Dsiaply Console
+		if (clk >= clkb2 + 1000) {
+			printf(str);
+			if (kbhit() && getchar() == '.')
+				break;
+			clkb2 = clk / 1000 * 1000;
+		}
+	}
 
-over :
-   if (fd >= 0)
-     {
-	close(fd);
-	fd = -1;
-     }
+	over: if (fd >= 0) {
+		close(fd);
+		fd = -1;
+	}
 
-   printf ("=== num = %d ===\n", num);
+	printf("=== num = %d ===\n", num);
 
-   printf("exit (y / n) ? > ");
-   fflush(stdout);
-   exit(0);//scanf("%s", str);
-   if (str[0] == 'y')
-     {
+	printf("exit (y / n) ? > ");
+	fflush(stdout);
+	exit(0);   //scanf("%s", str);
+	if (str[0] == 'y') {
 //		exit(0);
-     }
-   else
-     {
-	goto start;
-     }
+	} else {
+		goto start;
+	}
 }
 
+void clear_packet(int fd) {
 
-void clear_packet(int fd)
-{
-   
-   // clear existing packet
-   int oldf = fcntl(fd, F_GETFL, 0);
-   fcntl(fd, F_SETFL, oldf | O_NONBLOCK);
-   unsigned char c;
-   while ( read(fd, &c, 1) != EOF );
-   fcntl(fd, F_SETFL, oldf);
+	// clear existing packet
+	int oldf = fcntl(fd, F_GETFL, 0);
+	fcntl(fd, F_SETFL, oldf | O_NONBLOCK);
+	unsigned char c;
+	while (read(fd, &c, 1) != EOF)
+		;
+	fcntl(fd, F_SETFL, oldf);
 }
 
 //#define  B921600  B57600
 #define   B921600 0010007
 
-int SetComAttr2(int fd)
-{
-   // Settings for USB?
-   struct termios newtio;
-   tcgetattr(fd, &newtio);
-   memset (&newtio.c_cc, 0, sizeof (newtio.c_cc));
-   newtio.c_cflag |= CS8 | CLOCAL | CREAD;
-   //newtio.c_cflag = B921600 | CS8 | CLOCAL | CREAD;
-   newtio.c_cflag &= ~(IHFLOW | OHFLOW);
-   newtio.c_iflag = IGNPAR;
-   newtio.c_oflag = 0;
-   newtio.c_lflag = 0;//ICANON;
-   //newtio.c_lflag |= IEXTEN; // QNX?
-   //newtio.c_lflag = 0;   
-		
-   newtio.c_cc[VMIN] = 1;
-   newtio.c_cc[VTIME] = 2;   
-   newtio.c_cc[VEOF] = 4;     /* Ctrl-d */
+int SetComAttr2(int fd) {
+	// Settings for USB?
+	struct termios newtio;
+	tcgetattr(fd, &newtio);
+	memset(&newtio.c_cc, 0, sizeof(newtio.c_cc));
+	newtio.c_cflag |= CS8 | CLOCAL | CREAD;
+	//newtio.c_cflag = B921600 | CS8 | CLOCAL | CREAD;
+	newtio.c_cflag &= ~(IHFLOW | OHFLOW);
+	newtio.c_iflag = IGNPAR;
+	newtio.c_oflag = 0;
+	newtio.c_lflag = 0;   //ICANON;
+	//newtio.c_lflag |= IEXTEN; // QNX?
+	//newtio.c_lflag = 0;
 
-   //printf("speed = %04o %d\n", B9600, B9600);
-   //printf("speed = %04o %d\n", B115200, B9600);
-   //printf("speed = %04o %d\n", B921600, B9600);   
+	newtio.c_cc[VMIN] = 1;
+	newtio.c_cc[VTIME] = 2;
+	newtio.c_cc[VEOF] = 4; /* Ctrl-d */
+
+	//printf("speed = %04o %d\n", B9600, B9600);
+	//printf("speed = %04o %d\n", B115200, B9600);
+	//printf("speed = %04o %d\n", B921600, B9600);
 #if 0
-   int n;
-   n = cfsetspeed(&newtio, 921600L);
-   //n = cfsetspeed(&newtio, 115200);
-   if (n<0)
-     {
-	char *pmesg = strerror(errno);
-	fprintf (stderr, "failed to cfsetspeed(): %s\n", pmesg);
-	exit(-1);
-     }
-#endif   
-   // activate new settings
-   tcflush (fd, TCIFLUSH);
-   if (tcsetattr (fd, TCSANOW, &newtio) < 0) 
-     {
-	printf("can not set attr");
-	exit(-1);
-     }
-		
-   sleep(1);
-		
-   int retval = tcflush(fd, TCIOFLUSH);
-   if (retval != 0) 
-     {
-	printf("tcflush failed\n");
-     }
-}
-
-
-
-int SetComAttr4(int fdc)
-{
-
-   int n;
-
-   struct termios term;
-   
-   n = tcgetattr(fdc, &term);
-   if (n < 0)
-     {
-	char *pmesg = strerror(errno);
-	fprintf (stderr, "failed to tcgetattr(): %s\n", pmesg);
-	goto over;
-     }
-   
-   bzero(&term, sizeof(term));
-
-   //term.c_cflag = B115200 | CS8 | CLOCAL | CREAD;
-   term.c_cflag = CS8 | CLOCAL | CREAD;
-#if 1
-   //n = cfsetspeed(&term, 115200L);
-   //n = cfsetspeed(&term, 230400L);      
-   //n = cfsetspeed(&term, 460800L);         
-   n = cfsetspeed(&term, 921600L);
-   //n = cfsetspeed(&term, 115200);
-   //n = cfsetspeed(&term, 19200);   
-   if (n<0)
-     {
-		
-	char *pmesg = strerror(errno);
-	fprintf (stderr, "failed to cfsetspeed(): %s\n", pmesg);
-	goto over;
-     }
-#endif
-   term.c_iflag = IGNPAR;
-   term.c_oflag = 0;
-   term.c_lflag = 0;/*ICANON;*/
-   //term.c_lflag = 0;/*ICANON;*/
-   term.c_lflag |= IEXTEN; // QNX?
-    
-   term.c_cc[VINTR]    = 0;     /* Ctrl-c */ 
-   term.c_cc[VQUIT]    = 0;     /* Ctrl-? */
-   term.c_cc[VERASE]   = 0;     /* del */
-   term.c_cc[VKILL]    = 0;     /* @ */
-   term.c_cc[VEOF]     = 4;     /* Ctrl-d */
-   term.c_cc[VTIME]    = 0;
-   term.c_cc[VMIN]     = 0;
-   //term.c_cc[VSWTC]    = 0;     /* '?0' */
-   term.c_cc[VSTART]   = 0;     /* Ctrl-q */ 
-   term.c_cc[VSTOP]    = 0;     /* Ctrl-s */
-   term.c_cc[VSUSP]    = 0;     /* Ctrl-z */
-   term.c_cc[VEOL]     = 0;     /* '?0' */
-   term.c_cc[VREPRINT] = 0;     /* Ctrl-r */
-   term.c_cc[VDISCARD] = 0;     /* Ctrl-u */
-   term.c_cc[VWERASE]  = 0;     /* Ctrl-w */
-   term.c_cc[VLNEXT]   = 0;     /* Ctrl-v */
-   term.c_cc[VEOL2]    = 0;     /* '?0' */
-   
-#ifdef __QNX__
-   term.c_cflag &= ~PARENB;           // disable parity check
-   term.c_cflag &= ~CSTOPB;           // 1 stop bit
-   term.c_cflag &= ~(IHFLOW | OHFLOW);
-   // settings for qnx
-   term.c_cc[VMIN] = 1;
-   term.c_cc[VTIME] = 0;
-#endif
-
-   //tcflush(fdc, TCIFLUSH);
-   n = tcsetattr(fdc, TCSANOW, &term);
-   if (n<0) 
-     {
-		
-	char *pmesg = strerror(errno);
-	fprintf (stderr, "failed to tcsetattr(): %s\n", pmesg);
-	goto over;
-     }
-
-   over:
-
-   sleep(2);
-   return (n);
-}
-
-
-int SetComAttr(int fdc)
+	int n;
+	n = cfsetspeed(&newtio, 921600L);
+	//n = cfsetspeed(&newtio, 115200);
+	if (n<0)
 	{
-	if (fdc < 0)
-	     {
-		char *pmesg = strerror(errno);
-		fprintf (stderr, "failed to open : %s\n", pmesg);
-		goto over;
-	     }
-	   
-	   
-	struct termios term;
-	int res = tcgetattr(fdc, &term);
-	if (res<0)
-	     {
-		char *pmesg = strerror(errno);
-		fprintf (stderr, "failed to tcgetattr(): %s\n", pmesg);
-		goto over;
-	     }
-	 cfmakeraw(&term);
-	 res = cfsetspeed(&term, 921600);
-//	 res = cfsetspeed(&term, 230400);
-	 if (res<0) 
-	     {
-		
 		char *pmesg = strerror(errno);
 		fprintf (stderr, "failed to cfsetspeed(): %s\n", pmesg);
+		exit(-1);
+	}
+#endif   
+	// activate new settings
+	tcflush(fd, TCIFLUSH);
+	if (tcsetattr(fd, TCSANOW, &newtio) < 0) {
+		printf("can not set attr");
+		exit(-1);
+	}
+
+	sleep(1);
+
+	int retval = tcflush(fd, TCIOFLUSH);
+	if (retval != 0) {
+		printf("tcflush failed\n");
+	}
+}
+
+int SetComAttr4(int fdc) {
+
+	int n;
+
+	struct termios term;
+
+	n = tcgetattr(fdc, &term);
+	if (n < 0) {
+		char *pmesg = strerror(errno);
+		fprintf(stderr, "failed to tcgetattr(): %s\n", pmesg);
 		goto over;
-	     }
+	}
 
-	 // settings for qnx
-	 term.c_iflag |= IGNPAR;            // Ignore characters with parity errors
-	 term.c_cflag |= (CLOCAL | CREAD);  // needed for QNX 6.3.2
-	 term.c_cflag &= ~PARENB;           // disable parity check
-	 term.c_cflag |= CS8;               // 8 data bit
-	 term.c_cflag &= ~CSTOPB;           // 1 stop bit
-	 //term.c_lflag = IEXTEN;
-	 term.c_oflag = 0; ///added
-	 term.c_lflag &= ~(ECHO | ECHOCTL | ECHONL);  // disable ECHO
-	   
-	 //
-	 term.c_iflag &= ~INPCK;
+	bzero(&term, sizeof(term));
 
-	 // settings for dynpick
-	   term.c_cc[VINTR]    = 0;     /* Ctrl-c */
-	   term.c_cc[VQUIT]    = 0;     /* Ctrl-? */	   term.c_cc[VERASE]   = 0;     /* del */
-	   term.c_cc[VKILL]    = 0;     /* @ */
-	   term.c_cc[VEOF]     = 4;     /* Ctrl-d */
-	   term.c_cc[VTIME]    = 0;
-	   term.c_cc[VMIN]     = 0;
-	   //term.c_cc[VSWTC]    = 0;     /* '?0' */
-	   term.c_cc[VSTART]   = 0;     /* Ctrl-q */ 
-	   term.c_cc[VSTOP]    = 0;     /* Ctrl-s */
-	   term.c_cc[VSUSP]    = 0;     /* Ctrl-z */
-	   term.c_cc[VEOL]     = 0;     /* '?0' */
-	   term.c_cc[VREPRINT] = 0;     /* Ctrl-r */
-	   term.c_cc[VDISCARD] = 0;     /* Ctrl-u */
-	   term.c_cc[VWERASE]  = 0;     /* Ctrl-w */
-	   term.c_cc[VLNEXT]   = 0;     /* Ctrl-v */
-	   term.c_cc[VEOL2]    = 0;     /* '?0' */
+	//term.c_cflag = B115200 | CS8 | CLOCAL | CREAD;
+	term.c_cflag = CS8 | CLOCAL | CREAD;
+#if 1
+	//n = cfsetspeed(&term, 115200L);
+	//n = cfsetspeed(&term, 230400L);
+	//n = cfsetspeed(&term, 460800L);
+	n = cfsetspeed(&term, 921600L)
+	;
+	//n = cfsetspeed(&term, 115200);
+	//n = cfsetspeed(&term, 19200);
+	if (n < 0) {
+
+		char *pmesg = strerror(errno);
+		fprintf(stderr, "failed to cfsetspeed(): %s\n", pmesg);
+		goto over;
+	}
+#endif
+	term.c_iflag = IGNPAR;
+	term.c_oflag = 0;
+	term.c_lflag = 0;/*ICANON;*/
+	//term.c_lflag = 0;/*ICANON;*/
+	term.c_lflag |= IEXTEN; // QNX?
+
+	term.c_cc[VINTR] = 0; /* Ctrl-c */
+	term.c_cc[VQUIT] = 0; /* Ctrl-? */
+	term.c_cc[VERASE] = 0; /* del */
+	term.c_cc[VKILL] = 0; /* @ */
+	term.c_cc[VEOF] = 4; /* Ctrl-d */
+	term.c_cc[VTIME] = 0;
+	term.c_cc[VMIN] = 0;
+	//term.c_cc[VSWTC]    = 0;     /* '?0' */
+	term.c_cc[VSTART] = 0; /* Ctrl-q */
+	term.c_cc[VSTOP] = 0; /* Ctrl-s */
+	term.c_cc[VSUSP] = 0; /* Ctrl-z */
+	term.c_cc[VEOL] = 0; /* '?0' */
+	term.c_cc[VREPRINT] = 0; /* Ctrl-r */
+	term.c_cc[VDISCARD] = 0; /* Ctrl-u */
+	term.c_cc[VWERASE] = 0; /* Ctrl-w */
+	term.c_cc[VLNEXT] = 0; /* Ctrl-v */
+	term.c_cc[VEOL2] = 0; /* '?0' */
+
 #ifdef __QNX__
-	 term.c_cflag &= ~(IHFLOW | OHFLOW);
+	term.c_cflag &= ~PARENB;           // disable parity check
+	term.c_cflag &= ~CSTOPB;// 1 stop bit
+	term.c_cflag &= ~(IHFLOW | OHFLOW);
+	// settings for qnx
+	term.c_cc[VMIN] = 1;
+	term.c_cc[VTIME] = 0;
 #endif
 
-	 // settings for qnx
-	 term.c_cc[VMIN] = 0;
-	 term.c_cc[VTIME] = 2;
+	//tcflush(fdc, TCIFLUSH);
+	n = tcsetattr(fdc, TCSANOW, &term);
+	if (n < 0) {
 
-	 res = tcsetattr(fdc, TCSANOW, &term);
-	 if (res<0) 
-	     {
 		char *pmesg = strerror(errno);
-		fprintf (stderr, "failed to tcsetattr(): %s\n", pmesg);
+		fprintf(stderr, "failed to tcsetattr(): %s\n", pmesg);
 		goto over;
-	     }
-
-over :
-	return (res);
 	}
+
+	over:
+
+	sleep(2);
+	return (n);
+}
+
+int SetComAttr(int fdc) {
+	if (fdc < 0) {
+		char *pmesg = strerror(errno);
+		fprintf(stderr, "failed to open : %s\n", pmesg);
+		goto over;
+	}
+
+	struct termios term;
+	int res = tcgetattr(fdc, &term);
+	if (res < 0) {
+		char *pmesg = strerror(errno);
+		fprintf(stderr, "failed to tcgetattr(): %s\n", pmesg);
+		goto over;
+	}
+	cfmakeraw(&term);
+	res = cfsetspeed(&term, 921600)
+	;
+//	 res = cfsetspeed(&term, 230400);
+	if (res < 0) {
+
+		char *pmesg = strerror(errno);
+		fprintf(stderr, "failed to cfsetspeed(): %s\n", pmesg);
+		goto over;
+	}
+
+	// settings for qnx
+	term.c_iflag |= IGNPAR;            // Ignore characters with parity errors
+	term.c_cflag |= (CLOCAL | CREAD);  // needed for QNX 6.3.2
+	term.c_cflag &= ~PARENB;           // disable parity check
+	term.c_cflag |= CS8;               // 8 data bit
+	term.c_cflag &= ~CSTOPB;           // 1 stop bit
+	//term.c_lflag = IEXTEN;
+	term.c_oflag = 0; ///added
+	term.c_lflag &= ~(ECHO | ECHOCTL | ECHONL);  // disable ECHO
+
+	//
+	term.c_iflag &= ~INPCK;
+
+	// settings for dynpick
+	term.c_cc[VINTR] = 0; /* Ctrl-c */
+	term.c_cc[VQUIT] = 0; /* Ctrl-? */
+	term.c_cc[VERASE] = 0; /* del */
+	term.c_cc[VKILL] = 0; /* @ */
+	term.c_cc[VEOF] = 4; /* Ctrl-d */
+	term.c_cc[VTIME] = 0;
+	term.c_cc[VMIN] = 0;
+	//term.c_cc[VSWTC]    = 0;     /* '?0' */
+	term.c_cc[VSTART] = 0; /* Ctrl-q */
+	term.c_cc[VSTOP] = 0; /* Ctrl-s */
+	term.c_cc[VSUSP] = 0; /* Ctrl-z */
+	term.c_cc[VEOL] = 0; /* '?0' */
+	term.c_cc[VREPRINT] = 0; /* Ctrl-r */
+	term.c_cc[VDISCARD] = 0; /* Ctrl-u */
+	term.c_cc[VWERASE] = 0; /* Ctrl-w */
+	term.c_cc[VLNEXT] = 0; /* Ctrl-v */
+	term.c_cc[VEOL2] = 0; /* '?0' */
+#ifdef __QNX__
+	term.c_cflag &= ~(IHFLOW | OHFLOW);
+#endif
+
+	// settings for qnx
+	term.c_cc[VMIN] = 0;
+	term.c_cc[VTIME] = 2;
+
+	res = tcsetattr(fdc, TCSANOW, &term);
+	if (res < 0) {
+		char *pmesg = strerror(errno);
+		fprintf(stderr, "failed to tcsetattr(): %s\n", pmesg);
+		goto over;
+	}
+
+	over: return (res);
+}
 

--- a/hironx_ros_bridge/robot/dynpick/test-com.c
+++ b/hironx_ros_bridge/robot/dynpick/test-com.c
@@ -141,13 +141,13 @@ int main() {
 
 		// Data Request
 		n = write(fd, "R", 1);
-		tcdrain(fd);
+		tcdrain(fd);  //  The tcdrain() function waits until all output has been physically transmitted to the device associated with fd, or until a signal is received.
 		printf("write data (ret %d)\n", n);
 
-		// Get Singale data
+		// Get Single data
 #define DATA_LENGTH 27
 		len = 0;
-		bzero(str, 27);
+		bzero(str, 27);  // Setting the first 27 bytes of the area starting `str` to zero.
 		struct timeval tm0, tm1;
 		gettimeofday(&tm0, NULL);
 		while (len < DATA_LENGTH) {

--- a/hironx_ros_bridge/robot/nitta/jr3_driver.cpp
+++ b/hironx_ros_bridge/robot/nitta/jr3_driver.cpp
@@ -21,10 +21,10 @@
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
-int io_read (resmgr_context_t * ctp, io_read_t * msg, RESMGR_OCB_T * ocb);	//
+int io_read(resmgr_context_t * ctp, io_read_t * msg, RESMGR_OCB_T * ocb);	//
 static char *buffer = (char *) "Hello world\n";	//
 
-void wait_t (void);		// wait for 3 sec.
+void wait_t(void);		// wait for 3 sec.
 
 #include "QNX101/jr3pci3.idm"
 
@@ -49,8 +49,6 @@ unsigned long MappedAddress;
 
 #define WriteJr3Pm2(addr,data,data2)	(*(int volatile *)ToJr3PciAddrH((addr)) = (int)(data));(*(int volatile *)ToJr3PciAddrL((addr)) = (int)(data2))
 
-
-
 #define WriteJr3Pm(addr,data)		WriteJr3Pm2((addr),(data) >> 8, (data))
 
 /* Read and Write from the data memory using bus relative addressing */
@@ -60,7 +58,6 @@ unsigned long MappedAddress;
 /* Read and Write from the data memory using 0 relative addressing */
 #define ReadJr3(addr) (ReadJr3Dm((addr) | Jr3DmAddrMask))
 #define WriteJr3(addr,data) WriteJr3Dm((addr) | Jr3DmAddrMask,data)
-
 
 static resmgr_connect_funcs_t ConnectFuncs;	//
 static resmgr_io_funcs_t IoFuncs;	//
@@ -82,160 +79,147 @@ volatile uint32_t Jr3BaseAddress1L;
  bit fields are shown with the lsb first
  */
 
-struct raw_channel
-{
-  uint16_t raw_time;
-  uint16_t dummy1;
-  int16_t raw_data;
-  int16_t dummy2;
-  int16_t reserved[2];
-  int16_t dummy3[2];
+struct raw_channel {
+	uint16_t raw_time;
+	uint16_t dummy1;
+	int16_t raw_data;
+	int16_t dummy2;
+	int16_t reserved[2];
+	int16_t dummy3[2];
 };
 
-struct force_array
-{
-  int16_t fx;
-  int16_t dummy1;
-  int16_t fy;
-  int16_t dummy2;
-  int16_t fz;
-  int16_t dummy3;
-  int16_t mx;
-  int16_t dummy4;
-  int16_t my;
-  int16_t dummy5;
-  int16_t mz;
-  int16_t dummy6;
-  int16_t v1;
-  int16_t dummy7;
-  int16_t v2;
-  int16_t dummy8;
+struct force_array {
+	int16_t fx;
+	int16_t dummy1;
+	int16_t fy;
+	int16_t dummy2;
+	int16_t fz;
+	int16_t dummy3;
+	int16_t mx;
+	int16_t dummy4;
+	int16_t my;
+	int16_t dummy5;
+	int16_t mz;
+	int16_t dummy6;
+	int16_t v1;
+	int16_t dummy7;
+	int16_t v2;
+	int16_t dummy8;
 };
 
-
-
-struct six_axis_array
-{
-  int16_t fx;
-  int16_t dummy1;
-  int16_t fy;
-  int16_t dummy2;
-  int16_t fz;
-  int16_t dummy3;
-  int16_t mx;
-  int16_t dummy4;
-  int16_t my;
-  int16_t dummy5;
-  int16_t mz;
-  int16_t dummy6;
+struct six_axis_array {
+	int16_t fx;
+	int16_t dummy1;
+	int16_t fy;
+	int16_t dummy2;
+	int16_t fz;
+	int16_t dummy3;
+	int16_t mx;
+	int16_t dummy4;
+	int16_t my;
+	int16_t dummy5;
+	int16_t mz;
+	int16_t dummy6;
 };
 
-struct vect_bits
-{
-  uint8_t fx:1;
-  uint8_t fy:1;
-  uint8_t fz:1;
-  uint8_t mx:1;
-  uint8_t my:1;
-  uint8_t mz:1;
-  uint8_t changedV1:1;
-  uint8_t changedV2:1;
-  int16_t dummy;
+struct vect_bits {
+	uint8_t fx :1;
+	uint8_t fy :1;
+	uint8_t fz :1;
+	uint8_t mx :1;
+	uint8_t my :1;
+	uint8_t mz :1;
+	uint8_t changedV1 :1;
+	uint8_t changedV2 :1;
+	int16_t dummy;
 };
 
-struct warning_bits
-{
-  uint8_t fx_near_set:1;
-  uint8_t fy_near_set:1;
-  uint8_t fz_near_set:1;
-  uint8_t mx_near_set:1;
-  uint8_t my_near_set:1;
-  uint8_t mz_near_set:1;
-  uint8_t reserved:8;
-  //uint8_t        reserved : 10; // this will use 3 byte
-  int16_t dummy;
+struct warning_bits {
+	uint8_t fx_near_set :1;
+	uint8_t fy_near_set :1;
+	uint8_t fz_near_set :1;
+	uint8_t mx_near_set :1;
+	uint8_t my_near_set :1;
+	uint8_t mz_near_set :1;
+	uint8_t reserved :8;
+	//uint8_t        reserved : 10; // this will use 3 byte
+	int16_t dummy;
 };
 
-struct error_bits
-{
-  uint8_t fx_sat:1;
-  uint8_t fy_sat:1;
-  uint8_t fz_sat:1;
-  uint8_t mx_sat:1;
-  uint8_t my_sat:1;
-  uint8_t mz_sat:1;
-  uint8_t researved:2;
-  //uint8_t       researved : 4; // this will use 3 byte
-  uint8_t memry_error:1;
-  uint8_t sensor_charge:1;
-  uint8_t system_busy:1;
-  uint8_t cal_crc_bad:1;
-  uint8_t watch_dog2:1;
-  uint8_t watch_dog:1;
-  int16_t dummy1;
+struct error_bits {
+	uint8_t fx_sat :1;
+	uint8_t fy_sat :1;
+	uint8_t fz_sat :1;
+	uint8_t mx_sat :1;
+	uint8_t my_sat :1;
+	uint8_t mz_sat :1;
+	uint8_t researved :2;
+	//uint8_t       researved : 4; // this will use 3 byte
+	uint8_t memry_error :1;
+	uint8_t sensor_charge :1;
+	uint8_t system_busy :1;
+	uint8_t cal_crc_bad :1;
+	uint8_t watch_dog2 :1;
+	uint8_t watch_dog :1;
+	int16_t dummy1;
 };
 
 char *force_units_str[] =
-  { (char *) "pound, inch*pound, inch*1000",
-(char *) "Newton, Newton*meter*10, mm*10", (char *) "kilogram-force*10, kilogram-Force*cm, mm*10",
-(char *) "kilopound, kiloinch*pound, inch*1000" };
+  {  (char *) "pound, inch*pound, inch*1000",
 
-enum force_units
-{
-  lbs_in_lbs_mils,
-  N_dNm_mm10,
-  kgf10_kgFcm_mm10,
-  klbs_kin_lbs_mils,
-  reserved_units_4,
-  reserved_units_5,
-  reserved_units_6,
-  reserved_units_7
+		(char *) "Newton, Newton*meter*10, mm*10",
+		(char *) "kilogram-force*10, kilogram-Force*cm, mm*10",
+		(char *) "kilopound, kiloinch*pound, inch*1000" };
+
+enum force_units {
+	lbs_in_lbs_mils,
+	N_dNm_mm10,
+	kgf10_kgFcm_mm10,
+	klbs_kin_lbs_mils,
+	reserved_units_4,
+	reserved_units_5,
+	reserved_units_6,
+	reserved_units_7
 };
 
-struct thresh_struct
-{
-  int16_t data_address;
-  int16_t dummy1;
-  int16_t threshold;
-  int16_t dummy2;
-  int16_t bit_pattern;
-  int16_t dummy3;
+struct thresh_struct {
+	int16_t data_address;
+	int16_t dummy1;
+	int16_t threshold;
+	int16_t dummy2;
+	int16_t bit_pattern;
+	int16_t dummy3;
 };
 
-struct le_struct
-{
-  int16_t latch_bits;
-  int16_t dummy1;
-  int16_t number_of_ge_thresholds;
-  int16_t dummy2;
-  int16_t number_of_le_thresholds;
-  int16_t dummy3;
-  thresh_struct thresholds[4];
-  int16_t reserved;
-  int16_t dummy4;
+struct le_struct {
+	int16_t latch_bits;
+	int16_t dummy1;
+	int16_t number_of_ge_thresholds;
+	int16_t dummy2;
+	int16_t number_of_le_thresholds;
+	int16_t dummy3;
+	thresh_struct thresholds[4];
+	int16_t reserved;
+	int16_t dummy4;
 };
 
-enum link_types
-{
-  end_x_form, tx, ty, tz, rx, ry, rz, neg
+enum link_types {
+	end_x_form, tx, ty, tz, rx, ry, rz, neg
 };
 
-struct links
-{
-  link_types link_type;
-  int16_t dummy1;
-  int16_t link_amount;
-  int16_t dummy2;
+struct links {
+	link_types link_type;
+	int16_t dummy1;
+	int16_t link_amount;
+	int16_t dummy2;
 };
 
-struct transform
-{
-  links link[8];
+struct transform {
+	links link[8];
 };
 
 
-struct force_sensor_data
-{
+struct force_sensor_data {
   raw_channel raw_channels[16];	/* offset 0x0000 */
   char copyright[0x18 * 4];	/* offset 0x0040 */
   int16_t reserved1[0x08 * 2];	/* offset 0x0058 */
@@ -337,434 +321,383 @@ struct force_sensor_data
   transform transforms[0x10];	/* offset 0x0200 */
 };
 
-
-typedef struct
-{
-  uint16_t msg_no;
-  char msg_data[255];
+typedef struct {
+	uint16_t msg_no;
+	char msg_data[255];
 } server_msg_t;
 
+int download(unsigned int base0, unsigned int base1) {
+	printf("Download %x %x\n", base0, base1);
 
-int
-download (unsigned int base0, unsigned int base1)
-{
-  printf ("Download %x %x\n", base0, base1);
+	int count;
+	int index = 0;
+	unsigned int Jr3BaseAddressH;
+	unsigned int Jr3BaseAddressL;
 
-  int count;
-  int index = 0;
-  unsigned int Jr3BaseAddressH;
-  unsigned int Jr3BaseAddressL;
+	Jr3BaseAddressH = base0;
+	Jr3BaseAddressL = base1;
 
-  Jr3BaseAddressH = base0;
-  Jr3BaseAddressL = base1;
+	/* The first line is a line count */
+	count = dsp[index++];
 
-  /* The first line is a line count */
-  count = dsp[index++];
+	/* Read in file while the count is no 0xffff */
+	while (count != 0xffff) {
+		int addr;
 
-  /* Read in file while the count is no 0xffff */
-  while (count != 0xffff)
-    {
-      int addr;
+		/* After the count is the address */
+		addr = dsp[index++];
 
-      /* After the count is the address */
-      addr = dsp[index++];
+		/* loop count times and write the data to the dsp memory */
+		while (count > 0) {
+			/* Check to see if this is data memory or program memory */
+			if (addr & 0x4000) {
+				int data = 0;
 
-      /* loop count times and write the data to the dsp memory */
-      while (count > 0)
-	{
-	  /* Check to see if this is data memory or program memory */
-	  if (addr & 0x4000)
-	    {
-	      int data = 0;
+				/* Data memory is 16 bits and is on one line */
+				data = dsp[index++];
+				WriteJr3Dm(addr, data);
+				count--;
+				if (data != ReadJr3Dm(addr)) {
+					printf("data addr: %4.4x out: %4.4x in: %4.4x\n", addr,
+							data, ReadJr3Dm(addr));
+				}
+			} else {
+				int data, data2;
+				int data3;
 
-	      /* Data memory is 16 bits and is on one line */
-	      data = dsp[index++];
-	      WriteJr3Dm (addr, data);
-	      count--;
-	      if (data != ReadJr3Dm (addr))
-		{
-		  printf ("data addr: %4.4x out: %4.4x in: %4.4x\n", addr,
-			  data, ReadJr3Dm (addr));
+				/* Program memory is 24 bits and is on two lines */
+				data = dsp[index++];
+				data2 = dsp[index++];
+				WriteJr3Pm2(addr, data, data2);
+				count -= 2;
+
+				/* Verify the write */
+				if (((data << 8) | (data2 & 0xff))
+						!= (data3 = ReadJr3Pm(addr))) {
+					//      printf("pro addr: %4.4x out: %6.6x in: %6.6x\n", addr, ((data << 8)|(data2 & 0xff)), /* ReadJr3Pm(addr) */ data3);
+				}
+			}
+			addr++;
 		}
-	    }
-	  else
-	    {
-	      int data, data2;
-	      int data3;
+		count = dsp[index++];
+	}
 
+	return 0;
 
-	      /* Program memory is 24 bits and is on two lines */
-	      data = dsp[index++];
-	      data2 = dsp[index++];
-	      WriteJr3Pm2 (addr, data, data2);
-	      count -= 2;
+}
 
-	      /* Verify the write */
-	      if (((data << 8) | (data2 & 0xff)) !=
-		  (data3 = ReadJr3Pm (addr)))
-		{
-		  //      printf("pro addr: %4.4x out: %6.6x in: %6.6x\n", addr, ((data << 8)|(data2 & 0xff)), /* ReadJr3Pm(addr) */ data3);
+void get_force_sensor_info(force_sensor_data * data, char *msg) {
+	struct tm t1, *soft_day, *cal_day;
+	;
+	time_t t2;
+	t1.tm_sec = t1.tm_min = t1.tm_hour = 0;
+	t1.tm_isdst = -1;
+	t1.tm_mon = 0;
+	t1.tm_year = data->software_year - 1900;
+	t1.tm_mday = data->software_day;
+	t2 = mktime(&t1);
+	soft_day = localtime(&t2);
+	t1.tm_sec = t1.tm_min = t1.tm_hour = 0;
+	t1.tm_isdst = -1;
+	t1.tm_mon = 0;
+	t1.tm_year = data->cal_year - 1900;
+	t1.tm_mday = data->cal_day;
+	t2 = mktime(&t1);
+	cal_day = localtime(&t2);
+	snprintf(msg, 128, "rom # %d, soft # %d, %d/%d/%d\n"
+			"serial # %d, model # %d, cal day %d/%d/%d\n"
+			"%s, %d bits, %d ch\n"
+			"(C) %c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c\n\n",
+			data->eeprom_ver_no, data->software_ver_no, soft_day->tm_mday,
+			soft_day->tm_mon + 1, soft_day->tm_year + 1900, data->serial_no,
+			data->model_no, cal_day->tm_mday, cal_day->tm_mon + 1,
+			cal_day->tm_year + 1900, force_units_str[1], data->bit,
+			data->channels, data->copyright[0 * 4 + 1],
+			data->copyright[1 * 4 + 1], data->copyright[2 * 4 + 1],
+			data->copyright[3 * 4 + 1], data->copyright[4 * 4 + 1],
+			data->copyright[5 * 4 + 1], data->copyright[6 * 4 + 1],
+			data->copyright[7 * 4 + 1], data->copyright[8 * 4 + 1],
+			data->copyright[9 * 4 + 1], data->copyright[10 * 4 + 1],
+			data->copyright[11 * 4 + 1], data->copyright[12 * 4 + 1],
+			data->copyright[13 * 4 + 1], data->copyright[14 * 4 + 1],
+			data->copyright[15 * 4 + 1], data->copyright[16 * 4 + 1],
+			data->copyright[17 * 4 + 1], data->copyright[18 * 4 + 1],
+			data->copyright[19 * 4 + 1], data->copyright[20 * 4 + 1],
+			data->copyright[21 * 4 + 1], data->copyright[22 * 4 + 1],
+			data->copyright[23 * 4 + 1]);
+}
+
+int message_callback(message_context_t * ctp, int type, unsigned flags,
+		void *handle) {
+	server_msg_t *msg;
+	int num;
+	char msg_reply[255];
+
+	/* cast a pointer to the message data */
+	msg = (server_msg_t *) ctp->msg;
+
+	/* Print out some usefull information on the message */
+	//printf( "\n\nServer Got Message:\n" );
+	//printf( "  type: %d\n" , type );
+	//printf( "  data: %s\n\n", msg->msg_data );
+	force_sensor_data *data_0;
+	force_sensor_data *data_1;
+	data_0 = (force_sensor_data *) (Jr3BaseAddress0H + (Jr3DmAddrMask << 2));
+	data_1 = (force_sensor_data *) (Jr3BaseAddress1H + (Jr3DmAddrMask << 2));
+
+	/* Build the reply message */
+	num = type - _IO_MAX;
+	switch (num) {
+	case 1:			// get data
+	{
+		float tmp[12] = { -1.0 * (float) data_0->filter0.fx
+				/ (float) data_0->full_scale.fx, -1.0
+				* (float) data_0->filter0.fy / (float) data_0->full_scale.fy,
+				-1.0 * (float) data_0->filter0.fz
+						/ (float) data_0->full_scale.fz, -1.0
+						* (float) data_0->filter0.mx
+						/ (float) data_0->full_scale.mx * 0.1, // Newton*meter*10
+				-1.0 * (float) data_0->filter0.my
+						/ (float) data_0->full_scale.my * 0.1, -1.0
+						* (float) data_0->filter0.mz
+						/ (float) data_0->full_scale.mz * 0.1, -1.0
+						* (float) data_1->filter0.fx
+						/ (float) data_1->full_scale.fx, -1.0
+						* (float) data_1->filter0.fy
+						/ (float) data_1->full_scale.fy, -1.0
+						* (float) data_1->filter0.fz
+						/ (float) data_1->full_scale.fz, -1.0
+						* (float) data_1->filter0.mx
+						/ (float) data_1->full_scale.mx * 0.1, -1.0
+						* (float) data_1->filter0.my
+						/ (float) data_1->full_scale.my * 0.1, -1.0
+						* (float) data_1->filter0.mz
+						/ (float) data_1->full_scale.mz * 0.1 };
+		memcpy(msg_reply, tmp, sizeof(float) * 12);
+	}
+		break;
+	case 2:			// update offset
+		data_0->offsets.fx += data_0->filter0.fx;
+		data_0->offsets.fy += data_0->filter0.fy;
+		data_0->offsets.fz += data_0->filter0.fz;
+		data_0->offsets.mx += data_0->filter0.mx;
+		data_0->offsets.my += data_0->filter0.my;
+		data_0->offsets.mz += data_0->filter0.mz;
+		data_1->offsets.fx += data_1->filter0.fx;
+		data_1->offsets.fy += data_1->filter0.fy;
+		data_1->offsets.fz += data_1->filter0.fz;
+		data_1->offsets.mx += data_1->filter0.mx;
+		data_1->offsets.my += data_1->filter0.my;
+		data_1->offsets.mz += data_1->filter0.mz;
+		break;
+	case 3:			// set filter
+		break;
+	case 4:			// get data
+		get_force_sensor_info(data_0, msg_reply);
+		get_force_sensor_info(data_1, msg_reply + strlen(msg_reply));
+		break;
+	}
+
+	/* Send a reply to the waiting (blocked) client */
+	MsgReply(ctp->rcvid, EOK, msg_reply, 256);
+	return 0;
+}
+
+int main(int argc, char **argv) {
+	resmgr_attr_t resmgr_attr;
+	message_attr_t message_attr;
+	dispatch_t *dpp;
+	dispatch_context_t *ctp, *ctp_ret;
+	int resmgr_id, message_id;
+
+	/* Create the Dispatch Interface */
+	dpp = dispatch_create();
+	if (dpp == NULL) {
+		fprintf(stderr, "dispatch_create() failed: %s\n", strerror(errno));
+		return EXIT_FAILURE;
+	}
+
+	memset(&resmgr_attr, 0, sizeof(resmgr_attr));
+	resmgr_attr.nparts_max = 1;
+	resmgr_attr.msg_max_size = 2048;
+
+	/* Setup the default I/O functions to handle open/read/write/... */
+	iofunc_func_init(_RESMGR_CONNECT_NFUNCS, &ConnectFuncs, _RESMGR_IO_NFUNCS,
+			&IoFuncs);
+
+	IoFuncs.read = io_read;
+
+	/* Setup the attribute for the entry in the filesystem */
+	iofunc_attr_init(&IoFuncAttr, S_IFNAM | 0666, 0, 0);
+	IoFuncAttr.nbytes = strlen(buffer) + 1;	//
+
+	resmgr_id = resmgr_attach(dpp, &resmgr_attr, "/dev/jr3q", _FTYPE_ANY, 0,
+			&ConnectFuncs, &IoFuncs, &IoFuncAttr);
+	if (resmgr_id == -1) {
+		fprintf(stderr, "resmgr_attach() failed: %s\n", strerror(errno));
+		return EXIT_FAILURE;
+	}
+
+	/* Setup PCI */
+	unsigned int flags = 0;
+	unsigned bus, function, index = 0;
+	unsigned devid, venid;
+	int result;
+	unsigned lastbus, version, hardware;
+	unsigned int address0;
+	void *bufptr;
+	unsigned int addr;
+
+	pci_attach(flags);
+	result = pci_present(&lastbus, &version, &hardware);
+	if (result == -1) {
+		printf("PCI BIOS not present!\n");
+	}
+	devid = DEVICEID;
+	venid = VENDORID;
+	result = pci_find_device(devid, venid, index, &bus, &function);
+	printf("result PCI %d\n", result);
+	printf("bus %d\n", bus);
+	printf("function %d\n", function);
+	pci_read_config_bus(bus, function, 0x10, 1, sizeof(unsigned int), bufptr);
+
+	address0 = *(unsigned int *) bufptr;
+	buffer = (char *) bufptr;
+	printf("Board addr 0x%x\n", *(unsigned int *) buffer);
+
+	Jr3BaseAddress0H = (volatile uint32_t) mmap_device_memory(NULL, 0x100000,
+			PROT_READ | PROT_WRITE | PROT_NOCACHE, 0, address0);
+	Jr3BaseAddress0L = (volatile uint32_t) mmap_device_memory(NULL, 0x100000,
+			PROT_READ | PROT_WRITE | PROT_NOCACHE, 0, address0 + Jr3NoAddrMask);
+	Jr3BaseAddressH = (volatile uint32_t) mmap_device_memory(NULL, 0x100000,
+			PROT_READ | PROT_WRITE | PROT_NOCACHE, 0, address0);
+	WriteJr3Dm(Jr3ResetAddr, 0);	// Reset DSP
+	wait_t();
+	download(Jr3BaseAddress0H, Jr3BaseAddress0L);
+	wait_t();
+
+	Jr3BaseAddress1H = (volatile uint32_t) mmap_device_memory(NULL, 0x100000,
+			PROT_READ | PROT_WRITE | PROT_NOCACHE, 0, address0 + 0x80000);
+	Jr3BaseAddress1L = (volatile uint32_t) mmap_device_memory(NULL, 0x100000,
+			PROT_READ | PROT_WRITE | PROT_NOCACHE, 0, address0 + 0x80000 +
+			Jr3NoAddrMask);
+	download(Jr3BaseAddress1H, Jr3BaseAddress1L);
+	wait_t();
+	/*
+	 Jr3BaseAddress2H = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ|PROT_WRITE|PROT_NOCACHE, 0, address0 + 0x100000);
+	 Jr3BaseAddress2L = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ|PROT_WRITE|PROT_NOCACHE, 0, address0 + 0x100000 + Jr3NoAddrMask);
+	 download(Jr3BaseAddress2H, Jr3BaseAddress2L);
+	 wait_t();
+
+	 Jr3BaseAddress3H = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ|PROT_WRITE|PROT_NOCACHE, 0, address0 + 0x180000);
+	 Jr3BaseAddress3L = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ|PROT_WRITE|PROT_NOCACHE, 0, address0 + 0x180000 + Jr3NoAddrMask);
+	 download(Jr3BaseAddress3H, Jr3BaseAddress3L);
+	 wait_t();
+	 */
+
+	//reset
+	*(uint16_t *) (Jr3BaseAddress0H + ((0x0200 | Jr3DmAddrMask) << 2)) =
+			(uint16_t) 0;
+	*(uint16_t *) (Jr3BaseAddress0H + ((0x00e7 | Jr3DmAddrMask) << 2)) =
+			(uint16_t) 0x0500;
+
+	/* Setup our message callback */
+	memset(&message_attr, 0, sizeof(message_attr));
+	message_attr.nparts_max = 1;
+	message_attr.msg_max_size = 4096;
+
+	/* Attach a callback (handler) for two message types */
+	message_id = message_attach(dpp, &message_attr, _IO_MAX + 1, _IO_MAX + 10,
+			message_callback, NULL);
+	if (message_id == -1) {
+		fprintf(stderr, "message_attach() failed: %s\n", strerror(errno));
+		return EXIT_FAILURE;
+	}
+
+	/* Setup a context for the dispatch layer to use */
+	ctp = dispatch_context_alloc(dpp);
+	if (ctp == NULL) {
+		fprintf(stderr, "dispatch_context_alloc() failed: %s\n",
+				strerror(errno));
+		return EXIT_FAILURE;
+	}
+
+	/* The "Data Pump" - get and process messages */
+	while (1) {
+		ctp_ret = dispatch_block(ctp);
+		if (ctp_ret) {
+			dispatch_handler(ctp);
+		} else {
+			fprintf(stderr, "dispatch_block() failed: %s\n", strerror(errno));
+			return EXIT_FAILURE;
 		}
-	    }
-	  addr++;
 	}
-      count = dsp[index++];
-    }
 
-
-  return 0;
-
+	return EXIT_SUCCESS;
 }
 
-void
-get_force_sensor_info (force_sensor_data * data, char *msg)
-{
-  struct tm t1, *soft_day, *cal_day;;
-  time_t t2;
-  t1.tm_sec = t1.tm_min = t1.tm_hour = 0;
-  t1.tm_isdst = -1;
-  t1.tm_mon = 0;
-  t1.tm_year = data->software_year - 1900;
-  t1.tm_mday = data->software_day;
-  t2 = mktime (&t1);
-  soft_day = localtime (&t2);
-  t1.tm_sec = t1.tm_min = t1.tm_hour = 0;
-  t1.tm_isdst = -1;
-  t1.tm_mon = 0;
-  t1.tm_year = data->cal_year - 1900;
-  t1.tm_mday = data->cal_day;
-  t2 = mktime (&t1);
-  cal_day = localtime (&t2);
-  snprintf (msg, 128,
-	    "rom # %d, soft # %d, %d/%d/%d\n"
-	    "serial # %d, model # %d, cal day %d/%d/%d\n"
-	    "%s, %d bits, %d ch\n"
-	    "(C) %c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c\n\n",
-	    data->eeprom_ver_no, data->software_ver_no, soft_day->tm_mday,
-	    soft_day->tm_mon + 1, soft_day->tm_year + 1900, data->serial_no,
-	    data->model_no, cal_day->tm_mday, cal_day->tm_mon + 1,
-	    cal_day->tm_year + 1900, force_units_str[1], data->bit,
-	    data->channels, data->copyright[0 * 4 + 1],
-	    data->copyright[1 * 4 + 1], data->copyright[2 * 4 + 1],
-	    data->copyright[3 * 4 + 1], data->copyright[4 * 4 + 1],
-	    data->copyright[5 * 4 + 1], data->copyright[6 * 4 + 1],
-	    data->copyright[7 * 4 + 1], data->copyright[8 * 4 + 1],
-	    data->copyright[9 * 4 + 1], data->copyright[10 * 4 + 1],
-	    data->copyright[11 * 4 + 1], data->copyright[12 * 4 + 1],
-	    data->copyright[13 * 4 + 1], data->copyright[14 * 4 + 1],
-	    data->copyright[15 * 4 + 1], data->copyright[16 * 4 + 1],
-	    data->copyright[17 * 4 + 1], data->copyright[18 * 4 + 1],
-	    data->copyright[19 * 4 + 1], data->copyright[20 * 4 + 1],
-	    data->copyright[21 * 4 + 1], data->copyright[22 * 4 + 1],
-	    data->copyright[23 * 4 + 1]);
-}
+int io_read(resmgr_context_t * ctp, io_read_t * msg, RESMGR_OCB_T * ocb) {
+	int nleft;
+	int nbytes;
+	int nparts;
+	int status;
 
+	if ((status = iofunc_read_verify(ctp, msg, ocb, NULL)) != EOK)
+		return (status);
 
+	if ((msg->i.xtype & _IO_XTYPE_MASK) != _IO_XTYPE_NONE)
+		return (ENOSYS);
 
-int
-message_callback (message_context_t * ctp, int type, unsigned flags,
-		  void *handle)
-{
-  server_msg_t *msg;
-  int num;
-  char msg_reply[255];
+	/*
+	 * on all reads (first and subsequent) calculate
+	 * how many bytes we can return to the client,
+	 * based upon the number of bytes available (nleft)
+	 * and the client's buffer size
+	 */
 
-  /* cast a pointer to the message data */
-  msg = (server_msg_t *) ctp->msg;
+	nleft = ocb->attr->nbytes - ocb->offset;
+	nbytes = min(msg->i.nbytes, nleft);
 
-  /* Print out some usefull information on the message */
-  //printf( "\n\nServer Got Message:\n" );
-  //printf( "  type: %d\n" , type );
-  //printf( "  data: %s\n\n", msg->msg_data );
+	if (nbytes > 0) {
+		/* set up the return data IOV */
+		SETIOV(ctp->iov, buffer + ocb->offset, nbytes);
 
-  force_sensor_data *data_0;
-  force_sensor_data *data_1;
-  data_0 = (force_sensor_data *) (Jr3BaseAddress0H + (Jr3DmAddrMask << 2));
-  data_1 = (force_sensor_data *) (Jr3BaseAddress1H + (Jr3DmAddrMask << 2));
+		/* set up the number of bytes (returned by client's read()) */
+		_IO_SET_READ_NBYTES(ctp, nbytes);
 
-  /* Build the reply message */
-  num = type - _IO_MAX;
-  switch (num)
-    {
-    case 1:			// get data
-      {
-	float tmp[12] = {
-	  -1.0 * (float) data_0->filter0.fx / (float) data_0->full_scale.fx,
-	  -1.0 * (float) data_0->filter0.fy / (float) data_0->full_scale.fy,
-	  -1.0 * (float) data_0->filter0.fz / (float) data_0->full_scale.fz,
-	  -1.0 * (float) data_0->filter0.mx / (float) data_0->full_scale.mx * 0.1, // Newton*meter*10
-	  -1.0 * (float) data_0->filter0.my / (float) data_0->full_scale.my * 0.1,
-	  -1.0 * (float) data_0->filter0.mz / (float) data_0->full_scale.mz * 0.1,
-	  -1.0 * (float) data_1->filter0.fx / (float) data_1->full_scale.fx,
-	  -1.0 * (float) data_1->filter0.fy / (float) data_1->full_scale.fy,
-	  -1.0 * (float) data_1->filter0.fz / (float) data_1->full_scale.fz,
-	  -1.0 * (float) data_1->filter0.mx / (float) data_1->full_scale.mx * 0.1,
-	  -1.0 * (float) data_1->filter0.my / (float) data_1->full_scale.my * 0.1,
-	  -1.0 * (float) data_1->filter0.mz / (float) data_1->full_scale.mz * 0.1
-	};
-	memcpy (msg_reply, tmp, sizeof (float) * 12);
-      }
-      break;
-    case 2:			// update offset
-      data_0->offsets.fx += data_0->filter0.fx;
-      data_0->offsets.fy += data_0->filter0.fy;
-      data_0->offsets.fz += data_0->filter0.fz;
-      data_0->offsets.mx += data_0->filter0.mx;
-      data_0->offsets.my += data_0->filter0.my;
-      data_0->offsets.mz += data_0->filter0.mz;
-      data_1->offsets.fx += data_1->filter0.fx;
-      data_1->offsets.fy += data_1->filter0.fy;
-      data_1->offsets.fz += data_1->filter0.fz;
-      data_1->offsets.mx += data_1->filter0.mx;
-      data_1->offsets.my += data_1->filter0.my;
-      data_1->offsets.mz += data_1->filter0.mz;
-      break;
-    case 3:			// set filter
-      break;
-    case 4:			// get data
-      get_force_sensor_info (data_0, msg_reply);
-      get_force_sensor_info (data_1, msg_reply + strlen (msg_reply));
-      break;
-    }
+		/*
+		 * advance the offset by the number of bytes
+		 * returned to the client.
+		 */
 
-  /* Send a reply to the waiting (blocked) client */
-  MsgReply (ctp->rcvid, EOK, msg_reply, 256);
-  return 0;
-}
+		ocb->offset += nbytes;
+		nparts = 1;
+	} else {
+		/* they've adked for zero bytes or they've already previously
+		 * read everything
+		 */
 
-
-
-int
-main (int argc, char **argv)
-{
-  resmgr_attr_t resmgr_attr;
-  message_attr_t message_attr;
-  dispatch_t *dpp;
-  dispatch_context_t *ctp, *ctp_ret;
-  int resmgr_id, message_id;
-
-  /* Create the Dispatch Interface */
-  dpp = dispatch_create ();
-  if (dpp == NULL)
-    {
-      fprintf (stderr, "dispatch_create() failed: %s\n", strerror (errno));
-      return EXIT_FAILURE;
-    }
-
-  memset (&resmgr_attr, 0, sizeof (resmgr_attr));
-  resmgr_attr.nparts_max = 1;
-  resmgr_attr.msg_max_size = 2048;
-
-  /* Setup the default I/O functions to handle open/read/write/... */
-  iofunc_func_init (_RESMGR_CONNECT_NFUNCS, &ConnectFuncs,
-		    _RESMGR_IO_NFUNCS, &IoFuncs);
-
-  IoFuncs.read = io_read;
-
-  /* Setup the attribute for the entry in the filesystem */
-  iofunc_attr_init (&IoFuncAttr, S_IFNAM | 0666, 0, 0);
-  IoFuncAttr.nbytes = strlen (buffer) + 1;	//
-
-  resmgr_id = resmgr_attach (dpp, &resmgr_attr, "/dev/jr3q", _FTYPE_ANY,
-			     0, &ConnectFuncs, &IoFuncs, &IoFuncAttr);
-  if (resmgr_id == -1)
-    {
-      fprintf (stderr, "resmgr_attach() failed: %s\n", strerror (errno));
-      return EXIT_FAILURE;
-    }
-
-  /* Setup PCI */
-  unsigned int flags = 0;
-  unsigned bus, function, index = 0;
-  unsigned devid, venid;
-  int result;
-  unsigned lastbus, version, hardware;
-  unsigned int address0;
-  void *bufptr;
-  unsigned int addr;
-
-  pci_attach (flags);
-  result = pci_present (&lastbus, &version, &hardware);
-  if (result == -1)
-    {
-      printf ("PCI BIOS not present!\n");
-    }
-  devid = DEVICEID;
-  venid = VENDORID;
-  result = pci_find_device (devid, venid, index, &bus, &function);
-  printf ("result PCI %d\n", result);
-  printf ("bus %d\n", bus);
-  printf ("function %d\n", function);
-  pci_read_config_bus (bus, function, 0x10, 1, sizeof (unsigned int), bufptr);
-
-  address0 = *(unsigned int *) bufptr;
-  buffer = (char *) bufptr;
-  printf ("Board addr 0x%x\n", *(unsigned int *) buffer);
-
-  Jr3BaseAddress0H =
-    (volatile uint32_t) mmap_device_memory (NULL, 0x100000,
-					    PROT_READ | PROT_WRITE |
-					    PROT_NOCACHE, 0, address0);
-  Jr3BaseAddress0L =
-    (volatile uint32_t) mmap_device_memory (NULL, 0x100000,
-					    PROT_READ | PROT_WRITE |
-					    PROT_NOCACHE, 0,
-					    address0 + Jr3NoAddrMask);
-  Jr3BaseAddressH =
-    (volatile uint32_t) mmap_device_memory (NULL, 0x100000,
-					    PROT_READ | PROT_WRITE |
-					    PROT_NOCACHE, 0, address0);
-  WriteJr3Dm (Jr3ResetAddr, 0);	// Reset DSP       
-  wait_t ();
-  download (Jr3BaseAddress0H, Jr3BaseAddress0L);
-  wait_t ();
-
-  Jr3BaseAddress1H =
-    (volatile uint32_t) mmap_device_memory (NULL, 0x100000,
-					    PROT_READ | PROT_WRITE |
-					    PROT_NOCACHE, 0,
-					    address0 + 0x80000);
-  Jr3BaseAddress1L =
-    (volatile uint32_t) mmap_device_memory (NULL, 0x100000,
-					    PROT_READ | PROT_WRITE |
-					    PROT_NOCACHE, 0,
-					    address0 + 0x80000 +
-					    Jr3NoAddrMask);
-  download (Jr3BaseAddress1H, Jr3BaseAddress1L);
-  wait_t ();
-/*
-			Jr3BaseAddress2H = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ|PROT_WRITE|PROT_NOCACHE, 0, address0 + 0x100000); 
-			Jr3BaseAddress2L = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ|PROT_WRITE|PROT_NOCACHE, 0, address0 + 0x100000 + Jr3NoAddrMask); 
-			download(Jr3BaseAddress2H, Jr3BaseAddress2L);
-			wait_t();
-
-			Jr3BaseAddress3H = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ|PROT_WRITE|PROT_NOCACHE, 0, address0 + 0x180000); 
-			Jr3BaseAddress3L = (volatile uint32_t)mmap_device_memory(NULL, 0x100000, PROT_READ|PROT_WRITE|PROT_NOCACHE, 0, address0 + 0x180000 + Jr3NoAddrMask); 
-			download(Jr3BaseAddress3H, Jr3BaseAddress3L);
-			wait_t();
-*/
-
-  //reset
-  *(uint16_t *) (Jr3BaseAddress0H + ((0x0200 | Jr3DmAddrMask) << 2)) =
-    (uint16_t) 0;
-  *(uint16_t *) (Jr3BaseAddress0H + ((0x00e7 | Jr3DmAddrMask) << 2)) =
-    (uint16_t) 0x0500;
-
-
-  /* Setup our message callback */
-  memset (&message_attr, 0, sizeof (message_attr));
-  message_attr.nparts_max = 1;
-  message_attr.msg_max_size = 4096;
-
-  /* Attach a callback (handler) for two message types */
-  message_id = message_attach (dpp, &message_attr, _IO_MAX + 1,
-			       _IO_MAX + 10, message_callback, NULL);
-  if (message_id == -1)
-    {
-      fprintf (stderr, "message_attach() failed: %s\n", strerror (errno));
-      return EXIT_FAILURE;
-    }
-
-  /* Setup a context for the dispatch layer to use */
-  ctp = dispatch_context_alloc (dpp);
-  if (ctp == NULL)
-    {
-      fprintf (stderr, "dispatch_context_alloc() failed: %s\n",
-	       strerror (errno));
-      return EXIT_FAILURE;
-    }
-
-  /* The "Data Pump" - get and process messages */
-  while (1)
-    {
-      ctp_ret = dispatch_block (ctp);
-      if (ctp_ret)
-	{
-	  dispatch_handler (ctp);
+		_IO_SET_READ_NBYTES(ctp, 0);
+		nparts = 0;
 	}
-      else
-	{
-	  fprintf (stderr, "dispatch_block() failed: %s\n", strerror (errno));
-	  return EXIT_FAILURE;
-	}
-    }
 
-  return EXIT_SUCCESS;
-}
+	/* mark the access time as invalid (we just accessed it) */
 
+	if (msg->i.nbytes > 0)
+		ocb->attr->flags |= IOFUNC_ATTR_ATIME;
 
-int
-io_read (resmgr_context_t * ctp, io_read_t * msg, RESMGR_OCB_T * ocb)
-{
-  int nleft;
-  int nbytes;
-  int nparts;
-  int status;
-
-  if ((status = iofunc_read_verify (ctp, msg, ocb, NULL)) != EOK)
-    return (status);
-
-  if ((msg->i.xtype & _IO_XTYPE_MASK) != _IO_XTYPE_NONE)
-    return (ENOSYS);
-
-  /*
-   * on all reads (first and subsequent) calculate
-   * how many bytes we can return to the client,
-   * based upon the number of bytes available (nleft)
-   * and the client's buffer size
-   */
-
-  nleft = ocb->attr->nbytes - ocb->offset;
-  nbytes = min (msg->i.nbytes, nleft);
-
-  if (nbytes > 0)
-    {
-      /* set up the return data IOV */
-      SETIOV (ctp->iov, buffer + ocb->offset, nbytes);
-
-      /* set up the number of bytes (returned by client's read()) */
-      _IO_SET_READ_NBYTES (ctp, nbytes);
-
-      /*
-       * advance the offset by the number of bytes
-       * returned to the client.
-       */
-
-      ocb->offset += nbytes;
-      nparts = 1;
-    }
-  else
-    {
-      /* they've adked for zero bytes or they've already previously
-       * read everything
-       */
-
-      _IO_SET_READ_NBYTES (ctp, 0);
-      nparts = 0;
-    }
-
-  /* mark the access time as invalid (we just accessed it) */
-
-  if (msg->i.nbytes > 0)
-    ocb->attr->flags |= IOFUNC_ATTR_ATIME;
-
-  return (_RESMGR_NPARTS (nparts));
-
+	return (_RESMGR_NPARTS(nparts));
 
 }
 
-void
-wait_t (void)
-{
-  struct timeval tv, tv1;
+void wait_t(void) {
+	struct timeval tv, tv1;
 
-  gettimeofday (&tv1, NULL);
+	gettimeofday(&tv1, NULL);
 
-  do
-    {
-      gettimeofday (&tv, NULL);
-    }
-  while (tv.tv_sec - tv1.tv_sec < 3);	// wait for 3 sec.
+	do {
+		gettimeofday(&tv, NULL);
+	} while (tv.tv_sec - tv1.tv_sec < 3);	// wait for 3 sec.
 
-  return;
+	return;
 }

--- a/hironx_ros_bridge/robot/nitta/sample.c
+++ b/hironx_ros_bridge/robot/nitta/sample.c
@@ -27,96 +27,83 @@ unsigned long MappedAddress;
 #define SENSOR2		0x100000
 #define SENSOR3		0x180000
 
-typedef struct
-{
-  uint16_t msg_no;
-  char msg_data[255];
+typedef struct {
+	uint16_t msg_no;
+	char msg_data[255];
 } client_msg_t;
 
-int
-main (int argc, char **argv)
-{
-  int fd;
-  int c;
-  client_msg_t msg;
-  int ret;
-  int num;
-  char msg_reply[255];
-  int i;
+int main(int argc, char **argv) {
+	int fd;
+	int c;
+	client_msg_t msg;
+	int ret;
+	int num;
+	char msg_reply[255];
+	int i;
 
-  printf ("\x1b[2J");
-  printf ("\x1b[0;0H");
+	printf("\x1b[2J");
+	printf("\x1b[0;0H");
 
-  num = 4;
+	num = 4;
 
-  /* Process any command line arguments */
-  while ((c = getopt (argc, argv, "n:")) != -1)
-    {
-      if (c == 'n')
-	{
-	  num = strtol (optarg, 0, 0);
+	/* Process any command line arguments */
+	while ((c = getopt(argc, argv, "n:")) != -1) {
+		if (c == 'n') {
+			num = strtol(optarg, 0, 0);
+		}
 	}
-    }
 
-  /* Open a connection to the server (fd == coid) */
-  fd = open ("/dev/jr3q", O_RDWR);
-  if (fd == -1)
-    {
-      fprintf (stderr, "Unable to open server connection: %s\n",
-	       strerror (errno));
-      return EXIT_FAILURE;
-    }
+	/* Open a connection to the server (fd == coid) */
+	fd = open("/dev/jr3q", O_RDWR);
+	if (fd == -1) {
+		fprintf(stderr, "Unable to open server connection: %s\n",
+				strerror(errno));
+		return EXIT_FAILURE;
+	}
 
-  /* Clear the memory for the msg and the reply */
-  memset (&msg, 0, sizeof (msg));
-  memset (&msg_reply, 0, sizeof (msg_reply));
+	/* Clear the memory for the msg and the reply */
+	memset(&msg, 0, sizeof(msg));
+	memset(&msg_reply, 0, sizeof(msg_reply));
 
-  /* Setup the message data to send to the server */
-  msg.msg_no = _IO_MAX + num;
-  snprintf (msg.msg_data, 254, "client %d requesting reply.", getpid ());
+	/* Setup the message data to send to the server */
+	msg.msg_no = _IO_MAX + num;
+	snprintf(msg.msg_data, 254, "client %d requesting reply.", getpid());
 
-  printf ("client: msg_no: _IO_MAX + %d\n", num);
-  fflush (stdout);
+	printf("client: msg_no: _IO_MAX + %d\n", num);
+	fflush(stdout);
 
-  i = 0;
-loop:
-  /* Send the data to the server and get a reply */
-  msg.msg_no = _IO_MAX + num;
-  ret = MsgSend (fd, &msg, sizeof (msg), msg_reply, 255);
-  if (ret == -1)
-    {
-      fprintf (stderr, "Unable to MsgSend() to server: %s\n",
-	       strerror (errno));
-      return EXIT_FAILURE;
-    }
-  if (num == 1)
-    {
-      float tmp[12];
-      memcpy (tmp, msg_reply, sizeof (float) * 12);
-      printf ("client: msg_reply: %7.3f %7.3f %7.3f %7.3f %7.3f %7.3f\n",
-	      tmp[0], tmp[1], tmp[2], tmp[3], tmp[4], tmp[5]);
-      printf ("                   %7.3f %7.3f %7.3f %7.3f %7.3f %7.3f\n",
-	      tmp[6], tmp[7], tmp[8], tmp[9], tmp[10], tmp[11]);
-    }
-  else
-    {
-      printf ("client: msg_reply:\n%s\n", msg_reply);
-    }
+	i = 0;
+	loop:
+	/* Send the data to the server and get a reply */
+	msg.msg_no = _IO_MAX + num;
+	ret = MsgSend(fd, &msg, sizeof(msg), msg_reply, 255);
+	if (ret == -1) {
+		fprintf(stderr, "Unable to MsgSend() to server: %s\n", strerror(errno));
+		return EXIT_FAILURE;
+	}
+	if (num == 1) {
+		float tmp[12];
+		memcpy(tmp, msg_reply, sizeof(float) * 12);
+		printf("client: msg_reply: %7.3f %7.3f %7.3f %7.3f %7.3f %7.3f\n",
+				tmp[0], tmp[1], tmp[2], tmp[3], tmp[4], tmp[5]);
+		printf("                   %7.3f %7.3f %7.3f %7.3f %7.3f %7.3f\n",
+				tmp[6], tmp[7], tmp[8], tmp[9], tmp[10], tmp[11]);
+	} else {
+		printf("client: msg_reply:\n%s\n", msg_reply);
+	}
 
-  if (num > 1)
-    num--;
+	if (num > 1)
+		num--;
 
-  usleep (100000);
-  if ((i % 20) == 0)
-    {
-      num = 4;
-    }
+	usleep(100000);
+	if ((i % 20) == 0) {
+		num = 4;
+	}
 
+	if (i++ < 100000)
+		goto loop;
 
-  if (i++ < 100000)
-    goto loop;
+	close(fd);
 
-  close (fd);
-
-  return EXIT_SUCCESS;
+	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Adding another QNX-compatible force sensor driver for HiroNXO. 

The whole software of the driver being added this time is based on [JR3 force sensor for HiroNXO](https://github.com/start-jsk/rtmros_hironx/tree/indigo-devel/hironx_ros_bridge/robot/nitta).

Unlike JR3 driver, the Dynpick driver here uses `/dev/serusbN` as a file descriptor, and the number is currently hardcoded (1 and 2).

One last note is that as noted in the cpp file, this driver is stored in this robot-specific package for not many reasons than they are slightly customized for the robot (as of Apr 2016 it takes 2 sensor inputs in a single cpp file. It also assumes the specific device file name). So if you can separate those as a standalone, generic package that'll be appreciated (please just let us know if you will at https://github.com/start-jsk/rtmros_hironx/issues)).
