### PR TITLE
[Travis] Permit ROS shadow repo failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,10 @@ language: generic
 compiler:
   - gcc
 env:
-  - ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin    USE_DEB=true
-  - ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin    USE_DEB=false
+  - ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin    USE_DEB=true  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+  - ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin    USE_DEB=true  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+  - ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin    USE_DEB=false ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
   - TEST_TYPE=work_with_315_1_10
-matrix:
-  allow_failures:
 notifications:
   email:
     recipients:
@@ -39,7 +38,7 @@ before_install: # Use this to prepare the system to install prerequisites or dep
   - export REPOSITORY_NAME=${PWD##*/}
   - export ROS_PARALLEL_JOBS="-j1 -l1"
   - echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
+  - sudo -E sh -c 'echo "deb $ROS_REPOSITORY_PATH trusty main" > /etc/apt/sources.list.d/ros-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update -qq
   - sudo apt-get install -qq -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin


### PR DESCRIPTION
When packages in ROS shadow-fixed repo are failing, Travis never passes with the current config (e.g. #450). So use the official repo as a default, and shadow repo as an option.
