### PR TITLE
[hironx_client.py] Default modelfile location

### DIFF
--- a/hironx_ros_bridge/scripts/hironx.py
+++ b/hironx_ros_bridge/scripts/hironx.py
@@ -52,6 +52,7 @@ import argparse
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='hiro command line interpreters')
+    parser.add_argument('--isreal', help='true if running against real robot. Default: false')
     parser.add_argument('--host', help='corba name server hostname')
     parser.add_argument('--port', help='corba name server port number')
     parser.add_argument('--modelfile', help='robot model file nmae')
@@ -66,7 +67,7 @@ if __name__ == '__main__':
     if not args.robot:
         args.robot = "RobotHardware0" if args.host else "HiroNX(Robot)0"
     if not args.modelfile:
-        args.modelfile = ""
+        args.modelfile = "/opt/jsk/etc/HIRONX/model/main.wrl" if args.host else ""
 
     # support old style format
     if len(unknown) >= 2:


### PR DESCRIPTION
For the file path of model file on the robot side (QNX), it's already set in [a ros_bridge launch](https://github.com/start-jsk/rtmros_hironx/blob/b9314a2e3b8aa04812651f715b234709559500ca/hironx_ros_bridge/launch/hironx_ros_bridge_real.launch#L12). But when you don't run ros_bridge, you have to manually specify via ipython like following, which is cumbersome.

```
ipython -i `rospack find hironx_ros_bridge`/scripts/hironx.py -- --host hiro --modelfile /opt/jsk/HIRONX/model/main.wrl
```

<s>With this PR, you can simply run as following even without ros_bridge.

```
ipython -i `rospack find hironx_ros_bridge`/scripts/hironx.py -- --host hiro 
```

</s>
Thanks to @longjie 
