### PR TITLE
[HIRONX py] Remove redundant connection for impedance controller RTC.

### DIFF
--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
@@ -174,13 +174,6 @@ class HIRONX(HrpsysConfigurator):
         self.setSelfGroups()
         self.hrpsys_version = self.fk.ref.get_component_profile().version
 
-        # connect ic if needed
-        for sensor in ['lhsensor' , 'rhsensor']:
-            if self.ic and self.ic.port(sensor) and self.ic.port(sensor).get_port_profile() and \
-                    not self.ic.port(sensor).get_port_profile().connector_profiles :
-                connectPorts(self.rh.port(sensor), self.ic.port(sensor))
-
-
     def goOffPose(self, tm=7):
         '''
         Move arms to the predefined (as member variable) pose where robot can


### PR DESCRIPTION
As directed at https://github.com/start-jsk/rtmros_hironx/issues/453#issuecomment-210500682
