### PR TITLE
(re-open) Add test to catch wrong exit of ros_client

### DIFF
--- a/hironx_ros_bridge/test/test-hironx-ros-bridge.test
+++ b/hironx_ros_bridge/test/test-hironx-ros-bridge.test
@@ -15,4 +15,10 @@
 
   <test test-name="joint_states_test" pkg="rostest" type="hztest" name="joint_states_test" time-limit="100"/>
 
+  <test test-name="test_no_moveit" pkg="hironx_ros_bridge" type="test_no_moveit.py" name="test_no_moveit"
+        args="HiroNX(Robot)0
+              $(find hironx_ros_bridge)/models/kawada-hironx.dae
+              -ORBInitRef NameService=corbaloc:iiop:localhost:$(arg corbaport)/NameService"
+         time-limit="100" />
+
 </launch>

--- a/hironx_ros_bridge/test/test_no_moveit.py
+++ b/hironx_ros_bridge/test/test_no_moveit.py
@@ -59,6 +59,7 @@ class TestNoMoveit(unittest.TestCase):
             print(err)
             self.assertTrue(p.returncode==0, "[%s] ==> return code is not 0" % (err))
         except Exception as e:
+            print('Exception caught in test_nomoveit: {}'.format(e))
             self.fail(str(e))
 
 if __name__ == '__main__':

--- a/hironx_ros_bridge/test/test_no_moveit.py
+++ b/hironx_ros_bridge/test/test_no_moveit.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2016, Tokyo Opensource Robotics Kyokai Association (TORK)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Tokyo Opensource Robotics Kyokai Association. nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+PKG = 'hironx_ros_bridge'
+import unittest
+
+import sys, subprocess
+
+class TestNoMoveit(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        True
+
+    @classmethod
+    def tearDownClass(cls):
+        True
+
+    def test_nomoveit(self):
+        '''
+        Test if the certain exception is returned when no ROS master is available.
+        '''
+        try:
+            p = subprocess.Popen(["rosrun", "hironx_ros_bridge", "hironx.py", sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            out, err = p.communicate()
+            print(out)
+            print(err)
+            self.assertTrue(p.returncode==0, "[%s] ==> return code is not 0" % (err))
+        except Exception as e:
+            self.fail(str(e))
+
+if __name__ == '__main__':
+    import rostest
+    rostest.rosrun(PKG, 'test_no_moveit', TestNoMoveit)


### PR DESCRIPTION
Replacing #441 to add an updated Travis config.
