### PR TITLE
Update ros.key acquision.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install: # Use this to prepare the system to install prerequisites or dep
   - export ROS_PARALLEL_JOBS="-j1 -l1"
   - echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
   - sudo -E sh -c 'echo "deb $ROS_REPOSITORY_PATH trusty main" > /etc/apt/sources.list.d/ros-latest.list'
-  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
+  - sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net --recv-key 0xB01FA116
   - sudo apt-get update -qq
   - sudo apt-get install -qq -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin
   - if [ $ROSWS == rosws ]; then sudo apt-get install -qq -y python-rosinstall     ; fi


### PR DESCRIPTION
[How to acquire apt key has changed since Indigo](http://wiki.ros.org/indigo/Installation/Ubuntu#indigo.2BAC8-Installation.2BAC8-Sources.Set_up_your_keys). 

Not sure how relevant this is since the older method has been working so far for Indigo, but Travis today fails (e.g. [this](https://travis-ci.org/start-jsk/rtmros_hironx/jobs/128789943)) at key acquisition. So it's better to update to the latest method.
