### PR TITLE
Accept collada file location for real.launch.

### DIFF
--- a/hironx_moveit_config/test/test_hironx_moveit.py
+++ b/hironx_moveit_config/test/test_hironx_moveit.py
@@ -43,6 +43,7 @@ import unittest
 from geometry_msgs.msg import Pose, PoseStamped
 from moveit_commander import MoveGroupCommander
 import rospy
+import tf
 
 from hironx_ros_bridge.ros_client import ROS_Client
 
@@ -209,6 +210,17 @@ class TestHironxMoveit(unittest.TestCase):
         self._ros.go_offpose()
         numpy.testing.assert_almost_equal(self._ros.MG_UPPERBODY.get_current_joint_values(),
                                           self.offpose_jointvals, 3)
+
+    def test_geometry_link_r4_r5(self):
+        ''' 
+            Trying to capture issues like https://github.com/tork-a/rtmros_nextage/issues/244
+        '''
+        TRANS_RARM4_RARM5 = [-0.047, 0.000, -0.090]  # Expected value.
+
+        tflistener = tf.TransformListener()
+        (trans, rot) = tflistener.lookupTransform("/RARM_JOINT5_Link", "/RARM_JOINT4_Link", rospy.Time(0))
+        [self.assertAlmostEqual(v_trans, v_expected, 3) for v_trans, v_expected in zip(trans, TRANS_RARM4_RARM5)]
+
 
 if __name__ == '__main__':
     import rostest

--- a/hironx_ros_bridge/launch/hironx_ros_bridge_real.launch
+++ b/hironx_ros_bridge/launch/hironx_ros_bridge_real.launch
@@ -1,4 +1,5 @@
 <launch>
+  <arg name="COLLADA_FILE" default="$(find hironx_ros_bridge)/models/kawada-hironx.dae" />
   <arg name="CONF_FILE_COLLISIONDETECT" default="$(find hironx_ros_bridge)/conf/hironx_realrobot_fixedpath.conf" />
   <arg name="corbaport" default="15005" />
   <arg name="MODEL_FILE" default="/opt/jsk/etc/HIRONX/model/main.wrl" /> <!-- This shouldn't be changed unless you know what you're doing -->
@@ -12,6 +13,7 @@
         args="--host $(arg nameserver) --port $(arg corbaport) --modelfile $(arg MODEL_FILE) --robot RobotHardware" />
 
   <include file="$(find hironx_ros_bridge)/launch/hironx_ros_bridge.launch" >
+    <arg name="COLLADA_FILE" value="$(arg COLLADA_FILE)" />
     <arg name="CONF_FILE_COLLISIONDETECT" value="$(arg CONF_FILE_COLLISIONDETECT)" />
     <arg name="corbaport" default="$(arg corbaport)" />
     <arg name="MODEL_FILE" value="$(arg MODEL_FILE)" />


### PR DESCRIPTION
A partial solution to the issue https://github.com/tork-a/rtmros_nextage/issues/244, which a NEXTAGE Open real robot owner is reporting and seems to be happening because the model files from two similar but not identical robots are being used.

With this PR, we will be able to specify the collada file location from NEXTAGE Open package so that wrong model files won't be used.
