### PR TITLE
[hironx.py] Remove an arg that was merged by mistake.

### DIFF
--- a/hironx_ros_bridge/scripts/hironx.py
+++ b/hironx_ros_bridge/scripts/hironx.py
@@ -52,7 +52,6 @@ import argparse
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='hiro command line interpreters')
-    parser.add_argument('--isreal', help='true if running against real robot. Default: false')
     parser.add_argument('--host', help='corba name server hostname')
     parser.add_argument('--port', help='corba name server port number')
     parser.add_argument('--modelfile', help='robot model file nmae')


### PR DESCRIPTION
In #452 I failed to follow the discussion https://github.com/start-jsk/rtmros_hironx/pull/452#issuecomment-211618295 completely; the removed line in this PR was not supposed to be merged.
