### PR TITLE
[hironx script] Better error msg when no ROS master found.

### DIFF
--- a/hironx_ros_bridge/scripts/hironx.py
+++ b/hironx_ros_bridge/scripts/hironx.py
@@ -79,7 +79,9 @@ if __name__ == '__main__':
     try:
         ros = ROS_Client()
     except socket.error as e:
-        print("\033[31m%s\033[0m" % (e.strerror))
+        errormsg = 'No ROS Master found. Without it, you cannot use ROS from this script, but can use RTM. ' + \
+                   'To use ROS, do not forget to run rosbridge. How to do so? --> http://wiki.ros.org/rtmros_nextage/Tutorials/Operating%20Hiro%2C%20NEXTAGE%20OPEN'
+        print("\033[31m%s\n%s\033[0m" % (e.strerror, errormsg))
 
 # for simulated robot
 # $ ./hironx.py


### PR DESCRIPTION
Currently users who don't run rosbridge gets an error message at the end of the following python command that says ROS initialization failed. This can easily confuse users as if the entire command execution failed. Also especially newer users wouldn't know what to do with that bland message. This PR improves by telling that 1) RTM initialization went successful 2) how to run rosbridge.

```
ipython -i `rospack find nextage_ros_bridge`/script/nextage.py -- --host nextage
```
