### PR TITLE
[fix] servoOn error that returns always -1 for robots without Servo Controller RTC for hands. 

### DIFF
--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
@@ -719,8 +719,10 @@ class HIRONX(HrpsysConfigurator2):
                       + _MSG_RESTART_QNX + ') and run the command again.')
                 return -1
         else:
-            print('hrpsys ServoController not found. ' + _MSG_RESTART_QNX + ' and run the command again.')
-            return -1
+            print('hrpsys ServoController not found. Ignore this if you' +
+                  ' do not intend to use hand servo (e.g. NEXTAGE Open).' +
+                  ' If you do intend, then' + _MSG_RESTART_QNX +
+                  ' and run the command again.')
 
         return 1
 

--- a/hironx_ros_bridge/test/test_hironx_controller.py
+++ b/hironx_ros_bridge/test/test_hironx_controller.py
@@ -39,6 +39,18 @@ class TestHiroController(TestHiro):
         #self.assertTrue(ret)
         self.assertTrue(True) # this is dummy, current simulate hiro does not have force sensor so it retunrs None
 
+    def test_hands_controller(self):
+        '''
+        If Servo Controller RTC are running (which will be always true for
+        the tests because it runs on simulation), kill it then test if servoOn
+        method still succeeds.
+        '''
+        if self.robot.sc_svc:
+            self.robot.sc_svc = None
+        else:
+            print('Servo Controller RTC is not running, so skipping this test.')
+            pass
+        self.assertEqual(self.robot.servoOn(), 1)
 
 if __name__ == '__main__':
     import rostest


### PR DESCRIPTION
As reported at inline comment https://github.com/start-jsk/rtmros_hironx/pull/398#pullrequestreview-5575278, `HIRONX.servoOn()` always returns `-1` when `Servo Controller RTC` is not found, regardless the result of servo status (i.e. even though all servos are turned on successfully, the method returns -1). This was introduced in #398 and released as hironx_ros_bridge 1.1.1.

```
In [2]: robot.servoOn()
Move to Actual State, Just a minute.
Turn on Hand Servo
hrpsys ServoController not found. You may want to restart QNX/ControllerBox afterward and run the command again.
Out[2]: -1
```
