### PR TITLE
[moveit config] Fix Interactive Marker size.

### DIFF
--- a/hironx_moveit_config/launch/moveit_viewnatto.rviz
+++ b/hironx_moveit_config/launch/moveit_viewnatto.rviz
@@ -204,7 +204,7 @@ Visualization Manager:
         Colliding Link Color: 255; 0; 0
         Goal State Alpha: 1
         Goal State Color: 250; 128; 0
-        Interactive Marker Size: 0
+        Interactive Marker Size: 0.3
         Joint Violation Color: 255; 0; 255
         Planning Group: right_arm
         Query Goal State: true


### PR DESCRIPTION
Same as https://github.com/tork-a/rtmros_nextage/pull/264, changing Interactive Marker's size to a moderate one.
