### PR TITLE
[fix][hironx script] Correct exception when no ROS master found.

### DIFF
--- a/hironx_ros_bridge/scripts/hironx.py
+++ b/hironx_ros_bridge/scripts/hironx.py
@@ -35,6 +35,8 @@
 
 import socket
 
+from rospy import ROSInitException
+
 try:  # catkin does not requires load_manifest
     import hironx_ros_bridge
 except:
@@ -78,9 +80,9 @@ if __name__ == '__main__':
     # ROS Client
     try:
         ros = ROS_Client()
-    except socket.error as e:
-        errormsg = 'No ROS Master found. Without it, you cannot use ROS from this script, but can use RTM. ' + \
-                   'To use ROS, do not forget to run rosbridge. How to do so? --> http://wiki.ros.org/rtmros_nextage/Tutorials/Operating%20Hiro%2C%20NEXTAGE%20OPEN'
+    except ROSInitException as e:
+        print("\033[31m%s\n%s\033[0m" % (e.strerror, errormsg))
+    except socket.error as e: 
         print("\033[31m%s\n%s\033[0m" % (e.strerror, errormsg))
 
 # for simulated robot

--- a/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py
@@ -82,7 +82,8 @@ class ROS_Client(RobotCommander):
         try:
             rospy.get_master().getSystemState()
         except socket.error as e:
-            errormsg = '[ros_client] ros master is not running, so do not create ros client...'
+            errormsg = 'No ROS Master found. Without it, you cannot use ROS from this script, but you can still use RTM without issues. ' + \
+                       'To use ROS, do not forget to run rosbridge. How to do so? --> http://wiki.ros.org/rtmros_nextage/Tutorials/Operating%20Hiro%2C%20NEXTAGE%20OPEN'
             raise ROSInitException(errormsg)
         except Exception as e:
             errormsg = '[ros_client] Unknown exception occurred, so do not create ros client...'


### PR DESCRIPTION
New error message in #471 was not appointed to the right exception as my comment https://github.com/start-jsk/rtmros_hironx/pull/471#pullrequestreview-6560964