### PR TITLE
[hrpiob] Upgrade for hrpsys 315.4.0 onward.

### DIFF
--- a/hironx_ros_bridge/robot/hrpiob/CMakeLists.txt
+++ b/hironx_ros_bridge/robot/hrpiob/CMakeLists.txt
@@ -39,14 +39,25 @@ link_directories(/opt/jsk/lib /usr/pkg/lib)
 #endif()
 
 # hrpsys-base
-#include(FindPkgConfig)
+include(FindPkgConfig)
 
 execute_process(
   COMMAND pkg-config --cflags-only-I hrpsys-base
   OUTPUT_VARIABLE HRPSYSBASE_CXX_FLAGS
   RESULT_VARIABLE RESULT)
 
+execute_process(
+  COMMAND pkg-config --modversion hrpsys-base
+  OUTPUT_VARIABLE HRPSYSBASE_VERSION
+  RESULT_VARIABLE RESULT) 
+
 message("HRPSYSBASE_CXX_FLAGS: ${HRPSYSBASE_CXX_FLAGS}")
+message("HRPSYSBASE_VERSION: ${HRPSYSBASE_VERSION}")
+if(NOT "${HRPSYSBASE_VERSION}" VERSION_LESS "315.4.0")
+  add_definitions(-DROBOT_IOB_VERSION=2)
+  message(STATUS "USE VERSION 2 OF IOB") 
+  message(STATUS "ADD DEFINITION -DROBOT_IOB_VERSION=2")
+endif() 
 
 add_definitions(${HRPSYSBASE_CXX_FLAGS})
 

--- a/hironx_ros_bridge/robot/hrpiob/iob.cpp
+++ b/hironx_ros_bridge/robot/hrpiob/iob.cpp
@@ -733,3 +733,35 @@ int read_digital_output(char *doutput)
 	else
 		return FALSE;
 }
+
+#ifndef defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
+/**
+ * @brief Needed for hrpsys 315.4.0 onward (added at https://github.com/fkanehiro/hrpsys-base/pull/598).
+ *        TODO Implement if we want to utilize this.
+ */
+int number_of_thermometers(void)
+{
+    std::fprintf(stdout, "number_of_thermometers not implemented. See https://github.com/start-jsk/rtmros_hironx/pull/481\n");
+    return 0;
+}
+
+/**
+ * @brief Needed for hrpsys 315.4.0 onward (added at https://github.com/fkanehiro/hrpsys-base/pull/598).
+ *        TODO Implement if we want to utilize this.
+ */
+int number_of_batteries(void)
+{
+    std::fprintf(stdout, "number_of_batteries not implemented. See https://github.com/start-jsk/rtmros_hironx/pull/481\n");
+    return 0;
+}
+
+/**
+ * @brief Needed for hrpsys 315.4.0 onward (added at https://github.com/fkanehiro/hrpsys-base/pull/598).
+ *        TODO Implement if we want to utilize this.
+ */
+int read_battery(char *battery)
+{
+    std::fprintf(stdout, "read_battery not implemented. See https://github.com/start-jsk/rtmros_hironx/pull/481\n");
+    return 0;
+}
++#endif

--- a/hironx_ros_bridge/robot/hrpiob/iob.cpp
+++ b/hironx_ros_bridge/robot/hrpiob/iob.cpp
@@ -764,4 +764,4 @@ int read_battery(char *battery)
     std::fprintf(stdout, "read_battery not implemented. See https://github.com/start-jsk/rtmros_hironx/pull/481\n");
     return 0;
 }
-+#endif
+#endif

--- a/hironx_ros_bridge/robot/hrpiob/nextage-open.hpp
+++ b/hironx_ros_bridge/robot/hrpiob/nextage-open.hpp
@@ -60,7 +60,6 @@ namespace NEXTAGE_OPEN
         virtual int wait_for_iob_signal(void) = 0;
         virtual long get_signal_period(void) = 0;
         
-        
         virtual int initializeJointAngle(const char *name, const char *option) = 0;
         virtual int read_digital_input(char *dIn) = 0;
         virtual int length_digital_input(void) = 0;

--- a/hironx_ros_bridge/robot/hrpiob/nextage-open.hpp
+++ b/hironx_ros_bridge/robot/hrpiob/nextage-open.hpp
@@ -67,6 +67,12 @@ namespace NEXTAGE_OPEN
         virtual int write_digital_output_with_mask(const char *doutput, const char *mask) = 0;
         virtual int length_digital_output(void) = 0;
         virtual int read_digital_output(char *doutput) = 0;
+
+        #if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
+            virtual int number_of_thermometers(void) = 0;
+            virtual int number_of_batteries(void) = 0;
+            virtual int read_battery(char *battery) = 0;
+        #endif
     };
 
 }

--- a/hironx_ros_bridge/robot/hrpiob/package.xml
+++ b/hironx_ros_bridge/robot/hrpiob/package.xml
@@ -1,0 +1,12 @@
+<package format="2">
+  <name>hrpiob</name>
+  <version>1.0.1</version>
+  <description>Hardware I/O interface definition for hrpsys-based robots specific to Kawada's NEXTAGE robot.
+  </description>
+  <author>Kawada Industries Inc.</author>
+  <author>Kawada Robotics Corporation</author>
+  <maintainer email="dev@opensource-robotics.tokyo.jp">TORK</maintainer>
+  <license>CC BY-NC 4.0</license>
+  <buildtool_depend>cmake</buildtool_depend>
+  <depend>hrpsys</depend>  
+</package>


### PR DESCRIPTION
- hrpsys backward compatibility
  - [x] launch rtcd https://github.com/start-jsk/rtmros_hironx/pull/481#issuecomment-268688365
  - [ ] client commands

----

Since hrpsys 315.4.0 with updated `RobotHardware`, rtcd on QNX fails on NEXTAGE Open as follows. `hrpiob` with this PR hopefully fixes the issue.

Please review @534o @emijah 

```
$ more /opt/jsk/var/log/rtcd.log 
Logger::Logger: streambuf address = 0x805fc70
hrpExecutionContext is registered
unknown symbol: number_of_thermometers
unknown symbol: number_of_batteries
unknown symbol: read_battery
Load failed.
:
Load failed.
unknown symbol: number_of_thermometers
unknown symbol: number_of_batteries
unknown symbol: read_battery
Load failed.
:
Load failed.
hrpExecutionContext is registered
Load failed.
Load failed.
Load failed.
sh: rtcprof_python: cannot execute - No such file or directory
Abort (core dumped)
```
