### PR TITLE
[hironx py] Let setTargetPose fail when invalid kinematic group name passed.

### DIFF
--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
@@ -208,8 +208,7 @@ class HrpsysConfigurator2(HrpsysConfigurator): ## JUST FOR TEST, REMOVE WHEN YOU
         # https://github.com/fkanehiro/hrpsys-base/pull/1063 resolves.
         if gname.upper() not in map (lambda x : x[0].upper(), self.Groups):
             print("setTargetPose failed. {} is not available in the kinematic groups. "
-                  "Check available Groups (by e.g. self.Groups/robot.Groups). "
-                  "Also check the case of the group name".format(gname))
+                  "Check available Groups (by e.g. self.Groups/robot.Groups). ".format(gname))
             return False
         if StrictVersion(self.seq_version) >= StrictVersion('315.2.5'):                         ### CHANGED
             if self.default_frame_name and frame_name is None:

--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
@@ -193,7 +193,7 @@ class HrpsysConfigurator2(HrpsysConfigurator): ## JUST FOR TEST, REMOVE WHEN YOU
         Move the end-effector to the given absolute pose.
         All d* arguments are in meter.
 
-        @param gname str: Name of the joint group.
+        @param gname str: Name of the joint group. Case-insensitive
         @param pos list of float: In meter.
         @param rpy list of float: In radian.
         @param tm float: Second to complete the command.
@@ -202,6 +202,15 @@ class HrpsysConfigurator2(HrpsysConfigurator): ## JUST FOR TEST, REMOVE WHEN YOU
         @return bool: False if unreachable.
         '''
         print(gname, frame_name, pos, rpy, tm)
+        # Same change as https://github.com/fkanehiro/hrpsys-base/pull/1113.
+        # This method should be removed as part of
+        # https://github.com/start-jsk/rtmros_hironx/pull/470, once
+        # https://github.com/fkanehiro/hrpsys-base/pull/1063 resolves.
+        if gname.upper() not in map (lambda x : x[0].upper(), self.Groups):
+            print("setTargetPose failed. {} is not available in the kinematic groups. "
+                  "Check available Groups (by e.g. self.Groups/robot.Groups). "
+                  "Also check the case of the group name".format(gname))
+            return False
         if StrictVersion(self.seq_version) >= StrictVersion('315.2.5'):                         ### CHANGED
             if self.default_frame_name and frame_name is None:
                 frame_name = self.default_frame_name


### PR DESCRIPTION
**Background**
(Same commit message as https://github.com/fkanehiro/hrpsys-base/pull/1113)
`setTargetPose` takes a kinematic group as its 1st arg. When invalid value passed, it still tries to solve IK and always fails with an IK solution failure message, which is ambiguous because it failed not because
the computation but because the target group name is simply invalid.

**Approach to fix**
With this change it first checks if the passed value is a registered kinematic group name and if not it fails with the reason accordingly.

**Additional note at rtmros_hironx**
The change is exactly the same as the PR to the upstream https://github.com/fkanehiro/hrpsys-base/pull/1113. This method (and along with others) should be removed as part of https://github.com/start-jsk/rtmros_hironx/pull/470, once https://github.com/fkanehiro/hrpsys-base/pull/1063 resolves.