### PR TITLE
[fix][Python] link name's default value for get* methods.

### DIFF
--- a/hironx_moveit_config/package.xml
+++ b/hironx_moveit_config/package.xml
@@ -5,11 +5,11 @@
   <description>
      An automatically generated package with all the configuration and launch files for using the HiroNX with the MoveIt Motion Planning Framework
   </description>
-  <author email="assistant@moveit.ros.org">MoveIt Setup Assistant</author>
   <author email="uesnaola@gmail.com">Urko Esnaola</author>
+  <author email="iiysaito@opensource-robotics.tokyo.jp">Isaac I.Y. Saito</author>
 
   <maintainer email="k-okada@jsk.t.u-tokyo.ac.jp">Kei Okada</maintainer>
-  <maintainer email="iisaito@opensource-robotics.tokyo.jp">Isaac Isao Saito</maintainer>
+  <maintainer email="dev@opensource-robotics.tokyo.jp">TORK</maintainer>
 
   <license>BSD</license>
 

--- a/hironx_ros_bridge/package.xml
+++ b/hironx_ros_bridge/package.xml
@@ -9,8 +9,9 @@
   </description>
 
   <maintainer email="k-okada@jsk.t.u-tokyo.ac.jp">Kei Okada</maintainer>
-  <maintainer email="iisaito@kinugarage.com">Isaac Isao Saito</maintainer>
+  <maintainer email="dev@opensource-robotics.tokyo.jp">TORK</maintainer>
   <author email="k-okada@jsk.t.u-tokyo.ac.jp">Kei Okada</author>
+  <author email="iiysaito@opensource-robotics.tokyo.jp">Isaac I.Y. Saito</author>
 
   <license>BSD</license>
   <license>CreativeCommons-by-nc-4.0</license>

--- a/rtmros_hironx/package.xml
+++ b/rtmros_hironx/package.xml
@@ -8,8 +8,9 @@
   </description> 
 
   <maintainer email="k-okada@jsk.t.u-tokyo.ac.jp">Kei Okada</maintainer>
-  <maintainer email="iisaito@kinugarage.com">Isaac IY Saito</maintainer>
+  <maintainer email="dev@opensource-robotics.tokyo.jp">TORK</maintainer>
   <author email="k-okada@jsk.t.u-tokyo.ac.jp">Kei Okada</author>
+  <author email="iiysaito@opensource-robotics.tokyo.jp">Isaac I.Y. Saito</author>
 
   <license>BSD</license>
   <url type="website">http://ros.org/wiki/rtmros_hironx/</url>


### PR DESCRIPTION
Same as https://github.com/fkanehiro/hrpsys-base/pull/1118.

Once https://github.com/fkanehiro/hrpsys-base/pull/1118 gets merged, we can revert the 1st commit of this PR.

And not to mention that once https://github.com/start-jsk/rtmros_hironx/pull/470 gets merged, we need to revert `HrpsysConfigurator2`.