### PR TITLE
[hironx_ros_bridge][test] Export a common test py module.

### DIFF
--- a/hironx_ros_bridge/src/hironx_ros_bridge/testutil/test_hironx_ros_bridge.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/testutil/test_hironx_ros_bridge.py
@@ -1,6 +1,39 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2014, JSK Lab, University of Tokyo
+# Copyright (c) 2014, TORK
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of JSK Lab, University of Tokyo, TORK, nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 PKG = 'hironx_ros_bridge'
 # rosbuild needs load_manifest
 try:

--- a/hironx_ros_bridge/test/test_hironx_ros_bridge_controller.py
+++ b/hironx_ros_bridge/test/test_hironx_ros_bridge_controller.py
@@ -1,7 +1,48 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from test_hironx_ros_bridge import *
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2014, JSK Lab, University of Tokyo
+# Copyright (c) 2014, TORK
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of JSK Lab, University of Tokyo, TORK, nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import numpy
+import rospy
+from tf.transformations import quaternion_matrix, euler_from_matrix
+import time
+
+from hironx_ros_bridge.testutil.test_hironx_ros_bridge import TestHiroROSBridge
+
+PKG = 'hironx_ros_bridge'
+
 
 class TestHiroROSBridgeController(TestHiroROSBridge):
 

--- a/hironx_ros_bridge/test/test_hironx_ros_bridge_pose.py
+++ b/hironx_ros_bridge/test/test_hironx_ros_bridge_pose.py
@@ -1,7 +1,48 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from test_hironx_ros_bridge import *
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2014, JSK Lab, University of Tokyo
+# Copyright (c) 2014, TORK
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of JSK Lab, University of Tokyo, TORK, nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import numpy
+import rospy
+from tf.transformations import quaternion_matrix, euler_from_matrix
+import time
+
+from hironx_ros_bridge.testutil.test_hironx_ros_bridge import TestHiroROSBridge
+
+PKG = 'hironx_ros_bridge'
+
 
 class TestHiroROSBridgePose(TestHiroROSBridge):
 

--- a/hironx_ros_bridge/test/test_hironx_ros_bridge_send.py
+++ b/hironx_ros_bridge/test/test_hironx_ros_bridge_send.py
@@ -1,7 +1,47 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from test_hironx_ros_bridge import *
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2014, JSK Lab, University of Tokyo
+# Copyright (c) 2014, TORK
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of JSK Lab, University of Tokyo, TORK, nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import rospy
+from tf.transformations import quaternion_matrix, euler_from_matrix
+import time
+
+from hironx_ros_bridge.testutil.test_hironx_ros_bridge import TestHiroROSBridge
+
+PKG = 'hironx_ros_bridge'
+
 
 class TestHiroROSBridgeSend(TestHiroROSBridge):
 


### PR DESCRIPTION
`hironx_ros_bridge/test/test_hironx_ros_bridge.py` provides a test class that can be commonly used, even from other HiroNXO packages.