### PR TITLE
[Dynpick QNX driver] Fix sample driver device path.

### DIFF
--- a/hironx_ros_bridge/robot/dynpick/sample_dynpick.c
+++ b/hironx_ros_bridge/robot/dynpick/sample_dynpick.c
@@ -61,7 +61,7 @@ main (int argc, char **argv)
     }
 
   /* Open a connection to the server (fd == coid) */
-  fd = open ("/dev/jr3q", O_RDWR);
+  fd = open ("/dev/serusb1", O_RDWR);
   if (fd == -1)
     {
       fprintf (stderr, "Unable to open server connection: %s\n",


### PR DESCRIPTION
Needs tested with the real hardware.

Not tested yet on QNX with the actual Dynpick device, but without this change the output was strange (the example below ocsillates too much while no force was applied).

```
$ /opt/jsk/bin/sample_dynpick  
:
client: msg_reply:   2.849   1.064  55.332  -7.385  52.254  -7.964
                    -1.640  -0.116   2.824   0.130   2.445   0.571
client: msg_reply:   1.576   0.292   2.292   1.029   2.028  -0.290
                    -1.622  -0.110   2.830   0.135   2.445   0.567
client: msg_reply:  -0.991   2.344  52.772  -5.849  52.254  -7.965
                    -1.626  -0.105   2.830   0.135   2.436   0.576

client: msg_reply:   3.361   1.064  52.260  -6.873  50.974  -7.970
                    -1.637  -0.117   2.824   0.133   2.446   0.564
client: msg_reply:   3.361   1.064  52.260  -6.873  50.974  -7.970
                    -1.626  -0.110   2.824   0.132   2.440   0.568
client: msg_reply:   3.361   1.064  52.260  -6.873  50.974  -7.970
                    -1.626  -0.105   2.823   0.130   2.452   0.568
client: msg_reply:   3.361   1.064  52.260  -6.873  50.974  -7.970
                    -1.623  -0.105   2.829   0.133   2.439   0.567
client: msg_reply:   3.361   1.064  52.260  -6.873  50.974  -7.970
                    -1.635  -0.113   2.823   0.130   2.457   0.567
client: msg_reply:   3.361   1.064  52.260  -6.873  50.974  -7.970
                    -1.632  -0.116   2.814   0.129   2.452   0.567
client: msg_reply:   3.361   1.064  52.260  -6.873  50.974  -7.970
                    -1.631  -0.107   2.823   0.135   2.452   0.565
client: msg_reply:   3.361   1.064  52.260  -6.873  50.974  -7.970
                    -1.626  -0.122   2.826   0.126   2.442   0.567
client: msg_reply:   3.361   1.064  52.260  -6.873  50.974  -7.970
                    -1.629  -0.114   2.824   0.135   2.446   0.571
client: msg_reply:   3.361   1.064  52.260  -6.873  50.974  -7.970
                    -1.628  -0.117   2.826   0.123   2.446   0.562
client: msg_reply:   3.361   1.064  52.260  -6.873  50.974  -7.970
                    -1.625  -0.114   2.817   0.130   2.458   0.579
client: msg_reply:   3.361   1.064  52.260  -6.873  50.974  -7.970
                    -1.617  -0.110   2.823   0.129   2.434   0.570
client: msg_reply:   3.361   1.064  52.260  -6.873  50.974  -7.970
                    -1.620  -0.123   2.835   0.123   2.439   0.567
client: msg_reply:   3.361   1.064  52.260  -6.873  50.974  -7.970
                    -1.619  -0.116   2.842   0.129   2.439   0.573
client: msg_reply:   3.361   1.064  52.260  -6.873  50.974  -7.970
                    -1.626  -0.117   2.818   0.129   2.448   0.571
client: msg_reply:   1.576   0.285   2.278   1.030   2.028  -0.288
                    -1.623  -0.119   2.827   0.123   2.434   0.567
client: msg_reply:   1.576   0.285   2.278   1.030   2.028  -0.288
                    -1.629  -0.104   2.832   0.135   2.446   0.565

client: msg_reply:   1.576   0.285   2.278   1.030   2.028  -0.288
                    -1.623  -0.108   2.827   0.129   2.440   0.568
client: msg_reply:   1.576   0.285   2.278   1.030   2.028  -0.288
                    -1.619  -0.119   2.829   0.124   2.443   0.550
client: msg_reply:   1.576   0.285   2.278   1.030   2.028  -0.288
                    -1.556  -0.099   2.814   0.138   2.452   0.564
client: msg_reply:   1.576   0.285   2.278   1.030   2.028  -0.288
                    -1.629  -0.117   2.826   0.129   2.439   0.582
client: msg_reply:   1.576   0.285   2.278   1.030   2.028  -0.288
                    -1.550  -0.087   2.820   0.133   2.446   0.561
client: msg_reply:   1.576   0.285   2.278   1.030   2.028  -0.288
                    -1.631  -0.119   2.826   0.126   2.445   0.567
client: msg_reply:   1.576   0.285   2.278   1.030   2.028  -0.288
                    -1.628  -0.114   2.826   0.123   2.443   0.564
client: msg_reply:   1.576   0.285   2.278   1.030   2.028  -0.288
                    -1.626  -0.111   2.826   0.129   2.451   0.582
client: msg_reply:   1.576   0.285   2.278   1.030   2.028  -0.288
                    -1.634  -0.108   2.824   0.129   2.455   0.549
```
