### PR TITLE
[ros_bridge] Improve error message when no running ROS found.

### DIFF
--- a/hironx_ros_bridge/scripts/hironx.py
+++ b/hironx_ros_bridge/scripts/hironx.py
@@ -52,6 +52,10 @@ from hironx_ros_bridge.ros_client import ROS_Client
 from hrpsys import rtm
 import argparse
 
+errormsg_noros = 'No ROS Master found. Without it, you cannot use ROS from' \
+                 ' this script, but can use RTM. To use ROS, do not forget' \
+                 ' to run rosbridge. How to do so? --> http://wiki.ros.org/rtmros_nextage/Tutorials/Operating%20Hiro%2C%20NEXTAGE%20OPEN'
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='hiro command line interpreters')
     parser.add_argument('--host', help='corba name server hostname')
@@ -81,9 +85,9 @@ if __name__ == '__main__':
     try:
         ros = ROS_Client()
     except ROSInitException as e:
-        print("\033[31m%s\n%s\033[0m" % (e.strerror, errormsg))
+        print('[nextage.py] {}'.format(e))
     except socket.error as e: 
-        print("\033[31m%s\n%s\033[0m" % (e.strerror, errormsg))
+        print("\033[31m%s\n%s\033[0m" % (e.strerror, errormsg_noros))
 
 # for simulated robot
 # $ ./hironx.py


### PR DESCRIPTION
Python's stacktrace for this particular exception doesn't mean much to users nor developers. Besides, the errormsg is meaningful enough. And `errormsg` variable was undefined.
```
$ ipython -i `rospack find hironx_ros_bridge`/script/hironx.py -- --host hironx
:
[hrpsys.py] initialized successfully
---------------------------------------------------------------------------
ROSInitException                          Traceback (most recent call last)
/usr/lib/python2.7/dist-packages/IPython/utils/py3compat.pyc in execfile(fname, *where)
    202             else:
    203                 filename = fname
--> 204             __builtin__.execfile(filename, *where)

/opt/ros/indigo/share/nextage_ros_bridge/script/nextage.py in <module>()
     81
     82     # ROS Client.
---> 83     ros = ROS_Client()
     84
     85 # for simulated robot

/opt/ros/indigo/lib/python2.7/dist-packages/hironx_ros_bridge/ros_client.pyc in __init__(self, jointgroups)
     85             errormsg = 'No ROS Master found. Without it, you cannot use ROS from this script, but you can still use RTM without issues. ' + \
     86                        'To use ROS, do not forget to run rosbridge. How to do so? --> http://wiki.ros.org/rtmros_nextage/Tutorials/Operating%20Hiro%2C%20NEXTAGE%20OPEN'
---> 87             raise ROSInitException(errormsg)
     88         except Exception as e:
     89             errormsg = '[ros_client] Unknown exception occurred, so do not create ros client...'

ROSInitException: No ROS Master found. Without it, you cannot use ROS from this script, but you can still use RTM without issues. To use ROS, do not forget to run rosbridge. How to do so? --> http://wiki.ros.org/rtmros_nextage/Tutorials/Operating%20Hiro%2C%20NEXTAGE%20OPEN
```