### PR TITLE
[WIP][hironx_clinet.py] Auto-complete impedance parameters.

### DIFF
--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
@@ -36,6 +36,7 @@ import math
 import numpy
 import os
 import time
+import xmlrpclib
 
 import roslib
 roslib.load_manifest("hrpsys")
@@ -43,8 +44,10 @@ from hrpsys.hrpsys_config import *
 import OpenHRP
 import OpenRTM_aist
 import OpenRTM_aist.RTM_IDL
+import rospy
 import rtm
 from waitInput import waitInputConfirm, waitInputSelect
+from geometry_msgs.msg import WrenchStamped
 
 from distutils.version import StrictVersion
 
@@ -383,6 +386,8 @@ class HIRONX(HrpsysConfigurator2):
             pass
         self.setSelfGroups()
         self.hrpsys_version = self.fk.ref.get_component_profile().version
+
+        self._wrench = None
 
     def goOffPose(self, tm=7):
         '''
@@ -1023,12 +1028,54 @@ class HIRONX(HrpsysConfigurator2):
     def stopImpedance_315_3(self, arm):
         return self.ic_svc.stopImpedanceController(arm)
 
+    def _find_ref_force(self, wrench_topic):
+        '''
+        @summary: Intended as a callback method for WrenchStamped subscriber.
+        @type wrench_topic: geometric_msgs.WrenchStamped
+        @since: 1.1.24 or higher
+        '''
+        self._wrench = wrench_topic.force
+
+    def _suggest_impedance_params(self, arm, **kwargs):
+        '''
+        @type kwargs: dict
+        @param kwargs: dictionary of the parameters that `startImpedance`
+                       method takes.
+        @since: 1.1.24 or higher
+        @rtype: dict
+        @return: Update kwargs and returns it.
+        '''
+        ref_force_suggested = []
+        # TODO if ROS master is not found, skip the Auto-complete section.
+        m = xmlrpclib.ServerProxy(os.environ['ROS_MASTER_URI'])
+        try:
+            code, msg, val = m.getSystemState('HIRONX')
+        except socket.error:
+            print('[startImpedance] No ROS master found.'
+                  'Skip auto-complete impedance parameters.')
+            return None
+
+        sensor_side = 'lhsensor'
+        if arm == 'rarm':
+            sensor_side = 'rhsensor'
+        rospy.Subscriber(sensor_side, WrenchStamped,
+                         self._find_ref_force)
+        rospy.sleep(3.0)  # Wait to subscribe a topic desired.
+        if not self._wrench:
+            print('[startImpedance] Wrench topic not found.'
+                  'Skip auto-complete impedance parameters.')
+        else:
+            ref_force_suggested[0] = -self._wrench.force.x
+            ref_force_suggested[1] = -self._wrench.force.y
+            ref_force_suggested[2] = -self._wrench.force.z
+        kwargs.update({'ref_force': ref_force_suggested})
+        return kwargs
+
     def startImpedance(self, arm, **kwargs):
         '''
-        Enable the ImpedanceController RT component.
-        This method internally calls startImpedance-*, hrpsys version-specific
-        method.
-
+        @summary: Enable the ImpedanceController RT component.
+                  This method internally calls startImpedance-*,
+                  hrpsys version-specific method.
         @requires: ImpedanceController RTC to be activated on the robot's
                    controller.
         @param arm: Name of the kinematic group (i.e. self.Groups[n][0]).
@@ -1059,6 +1106,8 @@ class HIRONX(HrpsysConfigurator2):
                    a sensor. See this link (https://github.com/fkanehiro/hrpsys-base/pull/434/files) for a concrete example.
         '''
         if StrictVersion(self.hrpsys_version) < StrictVersion('315.2.0'):
+            if 'ref_force' not in kwargs:
+                kwargs = self._suggest_impedance_params(arm, **kwargs)
             self.startImpedance_315_1(arm, **kwargs)
         elif StrictVersion(self.hrpsys_version) < StrictVersion('315.3.0'):
             self.startImpedance_315_2(arm, **kwargs)

--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
@@ -1005,7 +1005,7 @@ class HIRONX(HrpsysConfigurator2):
         '''
         r, p = self.ic_svc.getImpedanceControllerParam(arm)
         if not r:
-            print('{}, Failt to getImpedanceControllerParam({})'.format(self.configurator_name, arm))
+            print('{}, Failed to getImpedanceControllerParam({})'.format(self.configurator_name, arm))
             return False
         if M_p != None: p.M_p = M_p
         if D_p != None: p.M_p = D_p

--- a/hironx_ros_bridge/test/test_hironx_controller.py
+++ b/hironx_ros_bridge/test/test_hironx_controller.py
@@ -1,43 +1,76 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2015, Tokyo Opensource Robotics Kyokai Association (TORK)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Tokyo Opensource Robotics Kyokai Association. nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 from test_hironx import *
+
 
 class TestHiroController(TestHiro):
 
     # https://github.com/fkanehiro/hrpsys-base/blob/master/sample/SampleRobot/samplerobot_impedance_controller.py.in
-    def test_impedance_controller(self): # https://github.com/start-jsk/rtmros_hironx/issues/337
+    def test_impedance_controller(self):  # https://github.com/start-jsk/rtmros_hironx/issues/337
         if not self.robot.ic or self.robot.ic.ref.get_component_profile().version < '315.3.0':
             self.assertTrue(True)
             return True
         # although this is not stable rtc, we'll test them
         self.robot.goInitial(tm=1)
-        ret = self.robot.startImpedance('rarm') # this returns ret, this is bug
-        #self.assertTrue(ret)
-        ret = self.robot.seq_svc.setWrenches([0,0,0,0,0,0,
-                                              10,0,0,0,0,0,], 2.0);
-        #self.assertTrue(ret)
+        ret = self.robot.startImpedance('rarm')  # this returns ret, this is bug
+        # self.assertTrue(ret)
+        ret = self.robot.seq_svc.setWrenches([0, 0, 0, 0, 0, 0,
+                                              10, 0, 0, 0, 0, 0, ], 2.0)
+        # self.assertTrue(ret)
         self.robot.seq_svc.waitInterpolation();
-        ret = self.robot.seq_svc.setWrenches([0,0,0,0,0,0,
-                                              0,0,0,0,0,0,], 2.0);
-        #self.assertTrue(ret)
+        ret = self.robot.seq_svc.setWrenches([0, 0, 0, 0, 0, 0,
+                                              0, 0, 0, 0, 0, 0, ], 2.0)
+        # self.assertTrue(ret)
         self.robot.seq_svc.waitInterpolation();
-        ret = self.robot.seq_svc.setWrenches([0,0,0,0,0,0,
-                                              0,10,0,0,0,0,], 2.0);
-        #self.assertTrue(ret)
+        ret = self.robot.seq_svc.setWrenches([0, 0, 0, 0, 0, 0,
+                                              0, 10, 0, 0, 0, 0, ], 2.0)
+        # self.assertTrue(ret)
         self.robot.seq_svc.waitInterpolation();
-        ret = self.robot.seq_svc.setWrenches([0,0,0,0,0,0,
-                                              0,0,0,0,0,0,], 2.0);
-        #self.assertTrue(ret)
+        ret = self.robot.seq_svc.setWrenches([0, 0, 0, 0, 0, 0,
+                                              0, 0, 0, 0, 0, 0, ], 2.0)
+        # self.assertTrue(ret)
         self.robot.seq_svc.waitInterpolation();
-        ret = self.robot.seq_svc.setWrenches([0,0,0,0,0,0,
-                                              0,0,10,0,0,0,], 2.0);
-        #self.assertTrue(ret)
-        self.robot.seq_svc.waitInterpolation();
-        #self.assertTrue(ret)
+        ret = self.robot.seq_svc.setWrenches([0, 0, 0, 0, 0, 0,
+                                              0, 0, 10, 0, 0, 0, ], 2.0)
+        # self.assertTrue(ret)
+        self.robot.seq_svc.waitInterpolation()
+        # self.assertTrue(ret)
         ret = self.robot.stopImpedance('rarm')
-        #self.assertTrue(ret)
-        self.assertTrue(True) # this is dummy, current simulate hiro does not have force sensor so it retunrs None
+        # self.assertTrue(ret)
+        self.assertTrue(True)  # this is dummy, current simulate hiro does not have force sensor so it retunrs None
 
     def test_hands_controller(self):
         '''
@@ -48,10 +81,10 @@ class TestHiroController(TestHiro):
         if self.robot.sc_svc:
             self.robot.sc_svc = None
         else:
-            print('Servo Controller RTC is not running, so skipping this test.')
+            print("Servo Controller RTC's not running, so skipping this test.")
             pass
         self.assertEqual(self.robot.servoOn(), 1)
 
 if __name__ == '__main__':
     import rostest
-    rostest.rosrun(PKG, 'test_hronx_controller', TestHiroController) 
+    rostest.rosrun(PKG, 'test_hronx_controller', TestHiroController)

--- a/hironx_ros_bridge/test/test_hironx_controller.py
+++ b/hironx_ros_bridge/test/test_hironx_controller.py
@@ -33,19 +33,21 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from distutils.version import StrictVersion
+
 from test_hironx import *
 
 
 class TestHiroController(TestHiro):
 
     # https://github.com/fkanehiro/hrpsys-base/blob/master/sample/SampleRobot/samplerobot_impedance_controller.py.in
-    def test_impedance_controller(self):  # https://github.com/start-jsk/rtmros_hironx/issues/337
+    def test_impedance_controller(self, **kwargs):  # https://github.com/start-jsk/rtmros_hironx/issues/337
         if not self.robot.ic or self.robot.ic.ref.get_component_profile().version < '315.3.0':
             self.assertTrue(True)
             return True
         # although this is not stable rtc, we'll test them
         self.robot.goInitial(tm=1)
-        ret = self.robot.startImpedance('rarm')  # this returns ret, this is bug
+        ret = self.robot.startImpedance('rarm', **kwargs)  # this returns ret, this is bug
         # self.assertTrue(ret)
         ret = self.robot.seq_svc.setWrenches([0, 0, 0, 0, 0, 0,
                                               10, 0, 0, 0, 0, 0, ], 2.0)
@@ -71,6 +73,41 @@ class TestHiroController(TestHiro):
         ret = self.robot.stopImpedance('rarm')
         # self.assertTrue(ret)
         self.assertTrue(True)  # this is dummy, current simulate hiro does not have force sensor so it retunrs None
+
+    def test_impedance_controller_refforce_315_1(self):
+        '''
+        @summary: Pass ref_force for hrpsys < 315.2.0.
+                  Although Impedance Controller is not a stable RTC,
+                  we'll test it.
+        '''
+        KIN_GROUP = 'rarm'  # Target kinematic group.
+        _REFFORCE_DEFAULT = [0.5, 0.5, 0.5]
+        _REFFORCE_2 = [0.5, 0.5, 0.5]
+        if not self.robot.ic or StrictVersion('315.2.0') <= StrictVersion(self.robot.hrpsys_version):
+            self.assertTrue(True)
+            return True
+
+        self.robot.goInitial(tm=1)
+        self.robot.startImpedance(KIN_GROUP)
+        # ic_svc.getImpedanceControllerParam returns something like:
+        #
+        # (True, OpenHRP.ImpedanceControllerService.impedanceParam(
+        #            M_p=100.0, D_p=200.0, K_p=400.0, M_r=2000.0, D_r=100.0, K_r=200.0, 
+        #            force_gain=[1.0, 1.0, 1.0], moment_gain=[0.0, 0.0, 0.0],
+        #            sr_gain=1.0, avoid_gain=0.0, reference_gain=0.0,
+        #            manipulability_limit=0.1, controller_mode=MODE_IMP,
+        #            ik_optional_weight_vector=[1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+        #            use_sh_base_pos_rpy=False))
+        self.assertListEqual(
+            _REFFORCE_DEFAULT,
+            self.robot.ic_svc.getImpedanceControllerParam(KIN_GROUP).ref_force)
+
+        # Test startImpedance with ref_force as an arg.
+        self.robot.startImpedance(KIN_GROUP, ref_force=_REFFORCE_2)
+        self.assertListEqual(
+            _REFFORCE_2,
+            self.robot.ic_svc.getImpedanceControllerParam(KIN_GROUP).ref_force)
+        self.robot.stopImpedance(KIN_GROUP)
 
     def test_hands_controller(self):
         '''


### PR DESCRIPTION
**DO NOT MERGE YET**

Parameters in `startImpedance` method is very important for the safety, as the robot's behavior can become unexpectable with inappropriate values. In my experience the "good" parameters change per runtime, and can only be figured by carefully observing the F/T sensor's output, and it's the user's responsibility to fill in the parameters.

Clearly all of these processes makes the method call error-prone.
This change intends to automatically fill the impedance parameters, in particular reference force "`ref_force`".

One concern is that this change makes `HIRONX` class and `hironx_client.py` module dependent on ROS, although the entire class/module have been ROS-agnostic. This is trivial and ok IMO, since there are other files in `hironx_ros_bridge` package that depends on ROS (i.e. ROS is everywhere).