### PR TITLE
[ros_bridge.py][startImpedance_315_3] More precise error message.

### DIFF
--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
@@ -1000,7 +1000,7 @@ class HIRONX(HrpsysConfigurator2):
         '''
         r, p = self.ic_svc.getImpedanceControllerParam(arm)
         if not r:
-            print('{}, Failt to getImpedanceControllerParam({})'.format(self.configurator_name, arm))
+            print('{}, impedance parameter not found for {}.'.format(self.configurator_name, arm))
             return False
         if M_p != None: p.M_p = M_p
         if D_p != None: p.M_p = D_p


### PR DESCRIPTION
When run by itself, `getImpedanceControllerParam` command at least finishes, so it's not failing. The error message is a bit misleading about what happened internally in `startImpedance_315_3` method.