### PR TITLE
Fix log fetch tool for QNX

### DIFF
--- a/hironx_ros_bridge/robot/qnx_fetch_log.sh
+++ b/hironx_ros_bridge/robot/qnx_fetch_log.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
 function usage {
-    echo >&2 "usage: $1 [hostname (default:hiro019)]"
+    echo >&2 "usage: $1 [hostname (default:nextage)]"
+    echo >&2 "       $2 [ossuser_qnx (default:tork)]"
     echo >&2 "          [-h|--help] Print help message."
     exit 0
 }
 
 # command line parse. If the num of argument is not as expected, call usage func.
 OPT=`getopt -o h -l help -- $*`
-if [ $# != 1 ]; then
+if [ $# -lt 1 ]; then
     usage
 fi
 
@@ -23,8 +24,9 @@ while [ -n "$1" ] ; do
 done
 
 hostname=$1
-hostname=${hostname:="hiro019"} 
-ossuser_qnx="tork"
+hostname=${hostname:="nextage"} 
+ossuser_qnx=$2
+ossuser_qnx=${ossuser_qnx:="tork"}
 OSS_FOLDER='/opt/jsk'
 OSS_FOLDER_LOG=${OSS_FOLDER}/var/log
 DATE=`date +"%Y%m%d-%H%M%S"`
@@ -52,6 +54,12 @@ commands="
   "
 
 IS_SUCCESS=1
+
+echo "** You can open the script and check inside **"
+echo "** if you are unsure about the content of this script. **"
+echo "** You can also find the same script source online at **"
+echo "** https://github.com/start-jsk/rtmros_hironx/blob/indigo-devel/hironx_ros_bridge/robot/qnx_fetch_log.sh **"
+echo "** Report if there's any issue for this script at https://github.com/start-jsk/rtmros_hironx/issues **"
 
 read -p "Run the command @ $hostname (y/n)? "
 if [ "$REPLY" == "y" ]; then

--- a/hironx_ros_bridge/robot/qnx_fetch_log.sh
+++ b/hironx_ros_bridge/robot/qnx_fetch_log.sh
@@ -3,6 +3,7 @@
 function usage {
     echo >&2 "usage: $1 [hostname (default:nextage)]"
     echo >&2 "       $2 [ossuser_qnx (default:tork)]"
+    echo >&2 "       $3 [date_specifier (default:none. Format: yyyymmdd, or it can be partial, e.g. yyyymm. Searches the files whose name matches the given string.)]"
     echo >&2 "          [-h|--help] Print help message."
     exit 0
 }
@@ -27,6 +28,8 @@ hostname=$1
 hostname=${hostname:="nextage"} 
 ossuser_qnx=$2
 ossuser_qnx=${ossuser_qnx:="tork"}
+date_specifier=$3
+date_specifier=${date_specifier:=""}  # By default this isn't set, so fetch files for all dates.
 OSS_FOLDER='/opt/jsk'
 OSS_FOLDER_LOG=${OSS_FOLDER}/var/log
 DATE=`date +"%Y%m%d-%H%M%S"`
@@ -47,7 +50,7 @@ commands="
   set +x;
 
   echo '* Create tarball of ${OSS_FOLDER_LOG} *';
-  tar cfvz opt_jsk_var_logs_${DATE}.tgz ${OSS_FOLDER_LOG}/* || echo '* Failed to create tarball *';
+  tar cfvz opt_jsk_var_logs_${DATE}.tgz ${OSS_FOLDER_LOG}/*${date_specifier}* || echo '* Failed to create tarball *';
 
   echo '* Exitting ssh session to QNX. *';
   exit;

--- a/hironx_ros_bridge/robot/qnx_fetch_log.sh
+++ b/hironx_ros_bridge/robot/qnx_fetch_log.sh
@@ -3,7 +3,8 @@
 function usage {
     echo >&2 "usage: $1 [hostname (default:nextage)]"
     echo >&2 "       $2 [ossuser_qnx (default:tork)]"
-    echo >&2 "       $3 [date_specifier (default:none. Format: yyyymmdd, or it can be partial, e.g. yyyymm. Searches the files whose name matches the given string.)]"
+    echo >&2 "       $3 [do_archive (default:1): If a string 'archive' is passed, remove all raw log files to save the disk space (date specified in 'date_after' will be ignored). Existing zip archives will not be deleted.]"
+    echo >&2 "       $4 [date_after (default:none. Format: yyyy-mm-dd or mmddyyyy): Do not operate on files modified prior to the specified date.]"
     echo >&2 "          [-h|--help] Print help message."
     exit 0
 }
@@ -28,29 +29,41 @@ hostname=$1
 hostname=${hostname:="nextage"} 
 ossuser_qnx=$2
 ossuser_qnx=${ossuser_qnx:="tork"}
-date_specifier=$3
-date_specifier=${date_specifier:=""}  # By default this isn't set, so fetch files for all dates.
+do_archive=$3
+do_archive=${do_archive:="1"}  # 1 is set by default. Actually anything other than "archive" is ignored.
+date_after=$4
+date_after=${date_after:="1970-01-01"}
 OSS_FOLDER='/opt/jsk'
 OSS_FOLDER_LOG=${OSS_FOLDER}/var/log
 DATE=`date +"%Y%m%d-%H%M%S"`
 TMP_FOLDER_ROOT=/tmp/HiroNXO_Log
-NAME_LOGFILE=${TMP_FOLDER_ROOT}/qnx_fetch_log_${hostname}_${DATE}.log
+NAME_LOGFILE_SCRIPT=${TMP_FOLDER_ROOT}/qnx_fetch_log_${hostname}_${DATE}.log
+NAME_LOGARCHIVE_FILE=opt_jsk_var_logs_${DATE}.zip
+NAME_LOGARCHIVE=/tmp/${NAME_LOGARCHIVE_FILE}
 
 mkdir ${TMP_FOLDER_ROOT}
 
+COMMAND_ARCHIVE=''
+if [ ${do_archive} == "archive" ]; then
+  echo "* Log files will be archived.";
+  COMMAND_ARCHIVE="rm ${OSS_FOLDER_LOG}/*.log; mv ${NAME_LOGARCHIVE} ${OSS_FOLDER_LOG}";
+  NAME_LOGARCHIVE=${OSS_FOLDER_LOG}/${NAME_LOGARCHIVE_FILE}
+fi
+  
 # Command that gets run on QNX. 
 # - (Assumes remotely logged in to qnx via ssh)
-# - Create tarball of /opt/jsk/var/log/* at /home/tork
+# - Create tarball of /opt/jsk/var/log/* at /home/tork>
 # - Log out of QNX
 # - scp the tarball
 commands="
   . ~/.profile || echo '~/.profile does not exist. Move on anyway.';
   env;
   trap 'exit 1' ERR;
-  set +x;
+  set -x;
 
   echo '* Create tarball of ${OSS_FOLDER_LOG} *';
-  tar cfvz opt_jsk_var_logs_${DATE}.tgz ${OSS_FOLDER_LOG}/*${date_specifier}* || echo '* Failed to create tarball *';
+  zip -t ${date_after} ${NAME_LOGARCHIVE} ${OSS_FOLDER_LOG}/*.log;
+  eval ${COMMAND_ARCHIVE};
 
   echo '* Exitting ssh session to QNX. *';
   exit;
@@ -66,9 +79,9 @@ echo "** Report if there's any issue for this script at https://github.com/start
 
 read -p "Run the command @ $hostname (y/n)? "
 if [ "$REPLY" == "y" ]; then
-    ssh $ossuser_qnx@$hostname -t $commands 2>&1 | tee ${NAME_LOGFILE}
+    ssh $ossuser_qnx@$hostname -t $commands 2>&1 | tee ${NAME_LOGFILE_SCRIPT}
     echo "====="
-    scp $ossuser_qnx@$hostname:/home/$ossuser_qnx/opt_jsk_var_logs_${DATE}.tgz . | tee ${NAME_LOGFILE}
+    scp $ossuser_qnx@$hostname:${NAME_LOGARCHIVE} . | tee ${NAME_LOGFILE_SCRIPT}
 
     IS_SUCCESS=0
 else
@@ -80,5 +93,5 @@ else
 fi
 
 if [ "${IS_SUCCESS}" -eq 1 ]; then
-    echo "Operation unsuccessful. Send back log file: ${NAME_LOGFILE}"
+    echo "Operation unsuccessful. Send back log file: ${NAME_LOGFILE_SCRIPT}"
 fi

--- a/hironx_ros_bridge/robot/qnx_fetch_log.sh
+++ b/hironx_ros_bridge/robot/qnx_fetch_log.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function usage {
-    echo >&2 "usage: $0 [hostname (default:hiro019)]"
+    echo >&2 "usage: $1 [hostname (default:hiro019)]"
     echo >&2 "          [-h|--help] Print help message."
     exit 0
 }


### PR DESCRIPTION
There's already a tool to fetch log files from QNX (added in https://github.com/start-jsk/rtmros_hironx/pull/354) but I found it not functioning as I tested locally with QNX on vm. The changes in this PR gets the script work again.

This will also address #355.
This will also address https://github.com/start-jsk/hironx-package/issues/83.