### PR TITLE
robot_description before staring ROS_Client (RobotCommander)

### DIFF
--- a/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py
@@ -90,13 +90,13 @@ class ROS_Client(RobotCommander):
             rospy.logerr(errormsg)
             raise e
 
-        super(ROS_Client, self).__init__()  # This solves https://github.com/start-jsk/rtmros_hironx/issues/300
-
-        rospy.init_node('hironx_ros_client')
-
         if not rospy.has_param('robot_description'):
             rospy.logwarn('ROS Bridge is not started yet, Assuming you want just to use RTM')
             return
+
+        super(ROS_Client, self).__init__()  # This solves https://github.com/start-jsk/rtmros_hironx/issues/300
+
+        rospy.init_node('hironx_ros_client')
 
         # See the doc in the method for the reason why this line is still kept
         # even after this class has shifted MoveIt! intensive.


### PR DESCRIPTION
otherwise, we had error like this, when we do not start rosbridge

```
[addJointGroup] group name TORSO is already installed
[addJointGroup] group name HEAD is already installed
[addJointGroup] group name RARM is already installed
[addJointGroup] group name LARM is already installed
[ERROR] [1496982942.820135612]: Robot model parameter not found! Did you remap 'robot_description'?
Traceback (most recent call last):
  File "/home/k-okada/catkin_ws/src/rtmros_nextage/nextage_ros_bridge/script/nextage.py", line 89, in <module>
    ros = ROS_Client()
  File "/home/k-okada/catkin_ws/src/rtmros_hironx/hironx_ros_bridge/src/hironx_ros_bridge/ros_client.py", line 93, in __init__
    super(ROS_Client, self).__init__()  # This solves https://github.com/start-jsk/rtmros_hironx/issues/300
  File "/opt/ros/indigo/lib/python2.7/dist-packages/moveit_commander/robot.py", line 148, in __init__
    self._r = _moveit_robot_interface.RobotInterface(robot_description)
RuntimeError: RobotInterfacePython: invalid robot model
[hrpsys_py-4] process has finished cleanly
```