### PR TITLE
get nshost from rtmnameserver, sometimes nshost is different from rosmaster

### DIFF
--- a/hironx_ros_bridge/launch/hironx_ros_bridge.launch
+++ b/hironx_ros_bridge/launch/hironx_ros_bridge.launch
@@ -18,6 +18,7 @@
   <arg name="USE_ROBOT_POSE_EKF" default="false" />
 
   <!-- For rqt dashboard that needs to connect RTM nameserver -->
+  <param name="rtmnameserver_host" type="str" value="$(arg nameserver)" />
   <param name="rtmnameserver_port" type="int" value="$(arg corbaport)" />
   <param name="rtmnameserver_robotname" type="str" value="$(arg SIMULATOR_NAME)" />
 

--- a/hironx_ros_bridge/src/hironx_ros_bridge/command_widget.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/command_widget.py
@@ -76,10 +76,10 @@ class HironxoCommandPanel(QWidget):
         self._guicontext = guicontext
 
         # RTM Client
-        rtm.nshost = self.get_rosmaster_domain().hostname
+        rtm.nshost = rospy.get_param('rtmnameserver_host', 'localhost')
         rtm.nsport = rospy.get_param('rtmnameserver_port', '15005')
         robotname = rospy.get_param('rtmnameserver_robotname', 'HiroNX(Robot)0')
-        rospy.loginfo('Connecting to RTM nameserver. host={}, port={}, robotname={}'.format(rtm.nshost, rtm.nsport, robotname))
+        rospy.loginfo('Connecting to RTM nameserver. host={}, port={}, robotname={} using rtmnameserver_{{host,port,robotname}} ROS param'.format(rtm.nshost, rtm.nsport, robotname))
 
         self._rtm = HIRONX()
         self._rtm.init(robotname=robotname, url='')


### PR DESCRIPTION
This will close 
```
[INFO] [WallTime: 1504170344.438683] Connecting to RTM nameserver. host=localhost, port=15005, robotname=RobotHardware0
configuration ORB with localhost:15005
[ERROR] Connection Failed with the Nameserver (hostname=localhost port=15005).
Make sure the hostname is correct and the Nameserver is running.
CORBA.TRANSIENT(omniORB.TRANSIENT_ConnectFailed, CORBA.COMPLETED_NO)
[rqt_hironxo-20] process has died [pid 9254, exit code 1, cmd /opt/ros/indigo/lib/rqt_gui/rqt_gui --perspective-file /opt/ros/indigo/share/hironx_ros_bridge/resource/hironx_rqt_dashboard.perspective __name:=rqt_hironxo __log:=/home/nxouser/.ros/log/8e34050e-8e2b-11e7-865e-00187d13a95a/rqt_hironxo-20.log].
log file: /home/nxouser/.ros/log/8e34050e-8e2b-11e7-865e-00187d13a95a/rqt_hironxo-20*.log
[WARN] [WallTime: 1504170345.283978] CollisionDetector(CollisionDetector0) is not activated, waiting...
```
error