### PR TITLE
[hironx_client.py] run goInitial within checkEncoders

### DIFF
--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
@@ -887,6 +887,9 @@ class HIRONX(HrpsysConfigurator2):
         if self.sc_svc:
             self.sc_svc.servoOn()
 
+        print("Run 'goInitial'")
+        self.goInitial()
+
     def startImpedance_315_1(self, arm,
                        M_p = 100.0,
                        D_p = 100.0,


### PR DESCRIPTION
This is based on a real robot user observation https://github.com/start-jsk/rtmros_hironx/issues/507#issuecomment-313794080.

Needs to be tested on a real robot.