### PR TITLE
Add hand_joint_state_publisher.py

### DIFF
--- a/hironx_ros_bridge/launch/hironx_ros_bridge_real.launch
+++ b/hironx_ros_bridge/launch/hironx_ros_bridge_real.launch
@@ -8,6 +8,7 @@
   <arg name="USE_ROBOTHARDWARE" default="true" />
   <arg name="USE_SERVOCONTROLLER" default="true" />
   <arg name="USE_IMPEDANCECONTROLLER" default="false"/>
+  <arg name="USE_HAND_JOINT_STATE_PUBLISHER" default="true"/>
 
   <node name="hrpsys_py" pkg="hironx_ros_bridge" type="hironx.py" output="screen"
         args="--host $(arg nameserver) --port $(arg corbaport) --modelfile $(arg MODEL_FILE) --robot RobotHardware" />
@@ -22,4 +23,7 @@
     <arg name="USE_SERVOCONTROLLER" value="$(arg USE_SERVOCONTROLLER)" />
     <arg name="USE_IMPEDANCECONTROLLER" value="$(arg USE_IMPEDANCECONTROLLER)"/>
   </include>
+
+  <node if="$(arg USE_HAND_JOINT_STATE_PUBLISHER)"
+	name="hand_joint_state_publisher" type="hand_joint_state_publisher.py" pkg="hironx_ros_bridge"/>
 </launch>

--- a/hironx_ros_bridge/scripts/hand_joint_state_publisher.py
+++ b/hironx_ros_bridge/scripts/hand_joint_state_publisher.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import rospy
+from sensor_msgs.msg import JointState
+
+def joint_state_publisher():
+    rospy.init_node('hand_joint_state_publisher', anonymous=True)
+    pub = rospy.Publisher('joint_states', JointState, queue_size=1)
+    joint_list = ['LHAND_JOINT0', 'LHAND_JOINT1', 'LHAND_JOINT2', 'LHAND_JOINT3', 'RHAND_JOINT0', 'RHAND_JOINT1', 'RHAND_JOINT2', 'RHAND_JOINT3']
+    rospy.loginfo("{} publishes fake joint states of {}".format(rospy.get_name(), joint_list))
+    rate = rospy.Rate(3) # 3hz
+    while not rospy.is_shutdown():
+        joint_states = JointState()
+        joint_states.header.stamp = rospy.Time.now()
+        joint_states.name = []
+        joint_states.position = []
+        for joint in joint_list:
+            joint_states.name.append(joint)
+            joint_states.position.append(0)
+        rospy.logdebug(joint_states)
+        pub.publish(joint_states)
+        rate.sleep()
+
+if __name__ == '__main__':
+    try:
+        joint_state_publisher()
+    except rospy.ROSInterruptException:
+        pass


### PR DESCRIPTION
- HiroNX(ROS) has 15 dof model file in its control box
- MovIt has the 23 dofs model including hand joints
- Moveit doesn't work when the number of dof is differ
- hand_joint_state_publisher.py published the lacked hand's joint_states