### PR TITLE
Avoid node clashing when USE_COLLISIONCHECK is true

### DIFF
--- a/hironx_ros_bridge/launch/hironx_ros_bridge.launch
+++ b/hironx_ros_bridge/launch/hironx_ros_bridge.launch
@@ -48,7 +48,7 @@
 
   <!-- Collision detection here runs external to the robot (on Ubuntu) and 
        visualizes the distance between each links. -->
-  <include file="$(find hrpsys_ros_bridge)/launch/collision_detector.launch">
+  <include file="$(find hrpsys_ros_bridge)/launch/collision_detector.launch" unless="$(arg USE_COLLISIONCHECK)">
     <arg name="MODEL_FILE" value="$(arg MODEL_FILE)" />
     <arg name="CONF_FILE" value="$(arg CONF_FILE_COLLISIONDETECT)" />
     <arg name="corbaport" default="$(arg corbaport)" />

--- a/hironx_ros_bridge/launch/hironx_ros_bridge_real.launch
+++ b/hironx_ros_bridge/launch/hironx_ros_bridge_real.launch
@@ -8,6 +8,7 @@
   <arg name="USE_ROBOTHARDWARE" default="true" />
   <arg name="USE_SERVOCONTROLLER" default="true" />
   <arg name="USE_IMPEDANCECONTROLLER" default="false"/>
+  <arg name="USE_COLLISIONCHECK" default="false"/>
   <arg name="USE_HAND_JOINT_STATE_PUBLISHER" default="true"/>
 
   <!-- BEGIN:hrpsys.py setting -->
@@ -32,6 +33,7 @@
     <arg name="USE_ROBOTHARDWARE" value="$(arg USE_ROBOTHARDWARE)" />
     <arg name="USE_SERVOCONTROLLER" value="$(arg USE_SERVOCONTROLLER)" />
     <arg name="USE_IMPEDANCECONTROLLER" value="$(arg USE_IMPEDANCECONTROLLER)"/>
+    <arg name="USE_COLLISIONCHECK" value="$(arg USE_COLLISIONCHECK)"/>
   </include>
 
   <node if="$(arg USE_HAND_JOINT_STATE_PUBLISHER)"


### PR DESCRIPTION
When USE_COLLISIONCHECK tag is true node clashing occurs in `hironx_ros_bridge_real.launch`:
```
roslaunch file contains multiple nodes named [/collision_state].
Please check all <node> 'name' attributes to make sure they are unique.
Also check that $(anon id) use different ids.
The traceback for the exception was written to the log file
```
This can be solved by not calling `collision_detector.launch`, which is already included by setting `USE_COLLISIONCHECK` to true.

The argument is also added in `hironx_ros_bridge_real.launch`, so we can set it from command line. 

@pazeshun 