### PR TITLE
Adapt to PyQt5 for running hironx_dashboard on kinetic

### DIFF
--- a/hironx_ros_bridge/src/hironx_ros_bridge/command_widget.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/command_widget.py
@@ -43,8 +43,13 @@ from hrpsys import rtm
 from hrpsys_ros_bridge.hrpsys_dashboard import HrpsysDashboard
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import Qt, Signal
-from python_qt_binding.QtGui import (QHeaderView, QItemSelectionModel,
-                                     QWidget)
+try: # Qt 4
+    from python_qt_binding.QtGui import (QHeaderView, QItemSelectionModel,
+                                         QWidget)
+except ImportError: # Qt 5
+    from python_qt_binding.QtWidgets import QHeaderView, QWidget
+    from python_qt_binding.QtCore import QItemSelectionModel
+
 from rosgraph import Master
 from rospkg import RosPack
 import rospy

--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_dashboard.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_dashboard.py
@@ -34,7 +34,11 @@
 
 import os
 
-from python_qt_binding.QtGui import QMessageBox, QLabel, QPalette
+try: # Qt 4
+    from python_qt_binding.QtWidgets import QMessageBox, QLabel, QPalette
+except ImportError: # Qt 5
+    from python_qt_binding.QtWidgets import QMessageBox, QLabel
+    from python_qt_binding.QtGui import QPalette
 
 from hrpsys_ros_bridge.hrpsys_dashboard import HrpsysDashboard
 from rqt_robot_dashboard.widgets import MenuDashWidget


### PR DESCRIPTION
Allows using Hironx dashboard on ros kinetic.

The problem is that Ubuntu 16.04 uses PyQt5, which had some modules moved from QtGui to QtWidgets and so on.

This should support both PyQt4 and PyQt5.