### PR TITLE
fix import error when using Qt5

### DIFF
--- a/hironx_ros_bridge/src/hironx_ros_bridge/command_widget.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/command_widget.py
@@ -43,8 +43,12 @@ from hrpsys import rtm
 from hrpsys_ros_bridge.hrpsys_dashboard import HrpsysDashboard
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import Qt, Signal
-from python_qt_binding.QtGui import (QHeaderView, QItemSelectionModel,
-                                     QWidget)
+try:
+    from python_qt_binding.QtGui import (QHeaderView, QItemSelectionModel,
+                                         QWidget)
+except ImportError: #Qt5
+    from python_qt_binding.QtWidgets import QHeaderView, QWidget
+    from python_qt_binding.QtCore import QItemSelectionModel
 from rosgraph import Master
 from rospkg import RosPack
 import rospy

--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_dashboard.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_dashboard.py
@@ -33,9 +33,11 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import os
-
-from python_qt_binding.QtGui import QMessageBox, QLabel, QPalette
-
+try:
+    from python_qt_binding.QtGui import QMessageBox, QLabel, QPalette
+except ImportError: # Qt5
+    from python_qt_binding.QtWidgets import QMessageBox, QLabel
+    from python_qt_binding.QtGui import QPalette
 from hrpsys_ros_bridge.hrpsys_dashboard import HrpsysDashboard
 from rqt_robot_dashboard.widgets import MenuDashWidget
 


### PR DESCRIPTION
ubuntu 16.04 kinetic使用しているが、
$ rtmlaunch nextage_ros_bridge nextage_ros_bridge_simulation.launch
を実行するときにdashboardがうまく表示されないです。

Qtのバージョンの違いで一部モジュールの場所が変わったようです。
importの修正をしました。
良かったらマージしてください。
よろしくお願いします