### PR TITLE
[hironx_ros_bridge] Enable to run CollisionDetector RTC by setting conf (Robot.conf)

### DIFF
--- a/hironx_ros_bridge/CMakeLists.txt
+++ b/hironx_ros_bridge/CMakeLists.txt
@@ -44,7 +44,8 @@ configure_file(conf/xml.in                      ${PROJECT_SOURCE_DIR}/conf/${ROB
 configure_file(conf/nosim.xml.in                ${PROJECT_SOURCE_DIR}/conf/${ROBOT_NAME}_nosim.xml)
 configure_file(conf/conf.in                     ${PROJECT_SOURCE_DIR}/conf/${ROBOT_NAME}.conf)
 configure_file(conf/nosim.conf.in               ${PROJECT_SOURCE_DIR}/conf/${ROBOT_NAME}_nosim.conf)
-add_custom_target(${PROJECT_NAME}_model_files ALL DEPENDS ${PROJECT_SOURCE_DIR}/conf/${ROBOT_NAME}.RobotHardware.conf ${PROJECT_SOURCE_DIR}/conf/${ROBOT_NAME}_nosim.RobotHardware.conf ${PROJECT_SOURCE_DIR}/conf/${ROBOT_NAME}.xml ${PROJECT_SOURCE_DIR}/conf/${ROBOT_NAME}_nosim.xml ${PROJECT_SOURCE_DIR}/conf/${ROBOT_NAME}.conf ${PROJECT_SOURCE_DIR}/conf/${ROBOT_NAME}_nosim.conf)
+configure_file(conf/rtc_on_off_test.conf.in     ${PROJECT_SOURCE_DIR}/conf/${ROBOT_NAME}_rtc_on_off_test.conf)
+add_custom_target(${PROJECT_NAME}_model_files ALL DEPENDS ${PROJECT_SOURCE_DIR}/conf/${ROBOT_NAME}.RobotHardware.conf ${PROJECT_SOURCE_DIR}/conf/${ROBOT_NAME}_nosim.RobotHardware.conf ${PROJECT_SOURCE_DIR}/conf/${ROBOT_NAME}.xml ${PROJECT_SOURCE_DIR}/conf/${ROBOT_NAME}_nosim.xml ${PROJECT_SOURCE_DIR}/conf/${ROBOT_NAME}.conf ${PROJECT_SOURCE_DIR}/conf/${ROBOT_NAME}_nosim.conf ${PROJECT_SOURCE_DIR}/conf/${ROBOT_NAME}_rtc_on_off_test.conf)
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
@@ -104,6 +105,7 @@ add_rostest(test/test-hironx-ros-bridge.test)
 add_rostest(test/test-hironx-ros-bridge-send.test)
 add_rostest(test/test-hironx-ros-bridge-pose.test)
 add_rostest(test/test-hironx-ros-bridge-controller.test)
+add_rostest(test/test-hironx-rtc-on-off.test)
 
 if (CATKIN_ENABLE_TESTING)
   catkin_add_nosetests(test/test_no_ros.py)

--- a/hironx_ros_bridge/conf/rtc_on_off_test.conf.in
+++ b/hironx_ros_bridge/conf/rtc_on_off_test.conf.in
@@ -1,0 +1,10 @@
+model: file://@PROJECT_SOURCE_DIR@/models/@ROBOT_NAME@.dae
+dt: 0.005
+collision_pair: RARM_JOINT2:LARM_JOINT2 RARM_JOINT3:LARM_JOINT3 RARM_JOINT4:LARM_JOINT4 RARM_JOINT5:LARM_JOINT5
+end_effectors: rarm,RARM_JOINT5,CHEST_JOINT0,0.0,0.0,0.0,-0.57735027,-0.57735027,-0.57735027,-2.0943951023931953,larm,LARM_JOINT5,CHEST_JOINT0,0.0,0.0,0.0,-0.57735027,-0.57735027,-0.57735027,-2.0943951023931953,
+
+# RTC disable/enable settings which will be loaded via RobotHardware
+CollisionDetector.enable: YES
+ServoController.enable: NO
+DataLogger.enable: NOO  # Test case when typo exists
+

--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
@@ -474,20 +474,18 @@ class HIRONX(HrpsysConfigurator2):
 
         # Specific code to current HIRONX status:
         ## CollisionDetector.enable is not set in normal conf, but we must remove CollisionDetector
-        if self.ms and self.ms.ref and len(self.ms.ref.get_component_profiles()) > 0:
+        co_rtc = ['co', "CollisionDetector"]
+        if co_rtc not in rtclist:
+            pass
+        elif self.ms and self.ms.ref and len(self.ms.ref.get_component_profiles()) > 0:
             try:
-                enable = next(p for p
-                              in self.ms.ref.get_component_profiles()[0].properties
-                              if p.name == 'CollisionDetector.enable').value.value()
+                next(p for p
+                     in self.ms.ref.get_component_profiles()[0].properties
+                     if p.name == (co_rtc[1] + '.enable')).value.value()
             except StopIteration:
-                enable = 'NO'
-            if enable == 'NO':
-                try:
-                    rtclist.remove(['co', "CollisionDetector"])
-                except ValueError:  # list.remove(x): x not in list
-                    pass
+                rtclist.remove(co_rtc)
         else:
-            rtclist.remove(['co', "CollisionDetector"])
+            rtclist.remove(co_rtc)
 
         if hasattr(self, 'rmfo'):
             self.ms.load("RemoveForceSensorLinkOffset")

--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
@@ -448,10 +448,22 @@ class HIRONX(HrpsysConfigurator2):
             ['fk', "ForwardKinematics"],
             ['ic', "ImpedanceController"],
             ['el', "SoftErrorLimiter"],
-            # ['co', "CollisionDetector"],
             ['sc', "ServoController"],
             ['log', "DataLogger"],
             ]
+        if self.ms and self.ms.ref and len(self.ms.ref.get_component_profiles()) > 0:
+            try:
+                is_co_enabled = next(p for p in self.ms.ref.get_component_profiles()[0].properties
+                                     if p.name == 'is_collision_detector_enabled').value.value()
+            except StopIteration:
+                is_co_enabled = 'NO'
+            if is_co_enabled == 'YES':
+                tmpidx = rtclist.index(['el', "SoftErrorLimiter"])
+                rtclist = rtclist[0:tmpidx+1] + [['co', "CollisionDetector"]] + rtclist[tmpidx+1:]
+            elif is_co_enabled != 'NO':
+                print(self.configurator_name +
+                      "\033[31mConfig 'is_collision_detector_enabled' is " + is_co_enabled +
+                      ". Set YES or NO\033[0m")
         if hasattr(self, 'rmfo'):
             self.ms.load("RemoveForceSensorLinkOffset")
             self.ms.load("AbsoluteForceSensor")

--- a/hironx_ros_bridge/test/test-hironx-rtc-on-off.test
+++ b/hironx_ros_bridge/test/test-hironx-rtc-on-off.test
@@ -1,0 +1,18 @@
+<launch>
+  <arg name="corbaport" default="2809" />
+  <arg name="GUI" default="false" />
+
+  <!-- See https://github.com/start-jsk/rtmros_common/issues/416#issuecomment-46846623 -->
+  <node name="start_omninames" pkg="rtmbuild" type="start_omninames.sh" args="$(arg corbaport)" />
+
+  <include file="$(find hironx_ros_bridge)/launch/hironx_startup.launch" >
+    <arg name="GUI" value="$(arg GUI)" />
+    <arg name="LAUNCH_HRPSYSPY" value="false" />
+    <arg name="REALTIME" value="false" />
+    <arg name="CONF_FILE" value="$(find hironx_ros_bridge)/conf/kawada-hironx_rtc_on_off_test.conf" />
+    <arg name="corbaport" value="$(arg corbaport)" />
+  </include>
+
+  <test type="test_hironx_rtc_on_off.py" pkg="hironx_ros_bridge" test-name="test_hironx_rtc_on_off" time-limit="200" retry="4"
+        args="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService" />
+</launch>

--- a/hironx_ros_bridge/test/test_hironx_fullbody.py
+++ b/hironx_ros_bridge/test/test_hironx_fullbody.py
@@ -5,6 +5,9 @@ from test_hironx import *
 
 class TestHiroFullbody(TestHiro):
 
+    def test_collision_detector_disabled(self):
+        self.assertFalse(['co', "CollisionDetector"] in self.robot.getRTCList())
+
     def fullbody_init (self):
         self.filenames = []
         self.robot.seq_svc.removeJointGroup("larm")

--- a/hironx_ros_bridge/test/test_hironx_rtc_on_off.py
+++ b/hironx_ros_bridge/test/test_hironx_rtc_on_off.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from test_hironx import *
+
+class TestHironxRtcOnOff(TestHiro):
+
+    def test_rtc_on_off(self):
+        self.assertTrue(['co', "CollisionDetector"] in self.robot.getRTCList())
+        self.assertFalse(['sc', "ServoController"] in self.robot.getRTCList())
+        self.assertTrue(['log', "DataLogger"] in self.robot.getRTCList())
+
+
+if __name__ == '__main__':
+    import rostest
+    rostest.rosrun(PKG, 'test_hironx_rtc_on_off', TestHironxRtcOnOff)


### PR DESCRIPTION
Includes #537 

In our lab's HIRONX, CollisionDetector RTC (co.rtc) can run thanks to https://github.com/fkanehiro/hrpsys-base/pull/1283.
Previously, we just comment in [here](https://github.com/start-jsk/rtmros_hironx/blob/2.1.1/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py#L451) to run that RTC.
However, this cannot be merged to original repository, so some efforts are required for maintenance.

This PR solves that situation.
If you add the following line to `/opt/jsk/etc/HIRONX/hrprtc/Robot.conf` (inside the robot), `hironx.py` brings up CollisionDetector RTC:
```
# RTC disable/enable settings which will be loaded via RobotHardware
CollisionDetector.enable: YES
```
If that section doesn't exist (common users' case), the behavior of `hironx.py` doesn't change.

Also, this PR supports disabling other RTCs from the conf file:
```
ServoController.enable: NO
```
In addition, this PR includes test to check those features (#537).

Memo: Another solution is to load all executable RTCs (CollisionDetector in default HIRONX isn't compiled and executable), but if taking that solution, simulated robot will load CollisionDetector (because it's compiled in local PC).