### PR TITLE
force set ORBgiopMaxMsgSize=2147483648  for hironx_client.py

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,4 +1,4 @@
-$!/bin/bash
+#!/bin/bash
 
 set -x
 
@@ -10,7 +10,7 @@ function error {
   exit 1
 }
 
-trap error ERR
+#trap error ERR
 
 echo "Environment Variables"
 echo "CI_SOURCE_PATH=$CI_SOURCE_PATH"

--- a/hironx_calibration/package.xml
+++ b/hironx_calibration/package.xml
@@ -18,6 +18,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <!-- force build depend hironx_moveit_config, so that hrpsys(plain cmake) runs first -->
+  <build_depend>hironx_moveit_config</build_depend>
+  <run_depend>hironx_moveit_config</run_depend>
   <run_depend>calibration_estimation</run_depend>
   <run_depend>calibration_launch</run_depend>
 

--- a/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
+++ b/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py
@@ -41,6 +41,16 @@ import time
 import roslib
 roslib.load_manifest("hrpsys")
 from hrpsys.hrpsys_config import *
+
+# hot fix for https://github.com/start-jsk/rtmros_hironx/issues/539
+#  On 16.04 (omniorb4-dev 4.1) if we start openhrp-model-loader with
+# <env name="ORBgiopMaxMsgSize" value="2147483648" />
+# all connection(?) conect respenct giopMaxMsgSize
+#  But on 18.04 (omniorb4-dev 4.2) wnneed to set ORBgiopMaxMsgSize=2147483648
+# for each clients
+if not os.environ.has_key('ORBgiopMaxMsgSize'):
+    os.environ['ORBgiopMaxMsgSize'] = '2147483648'
+
 import OpenHRP
 import OpenRTM_aist
 import OpenRTM_aist.RTM_IDL

--- a/hironx_ros_bridge/test/test-hironx-ros-bridge.test
+++ b/hironx_ros_bridge/test/test-hironx-ros-bridge.test
@@ -19,6 +19,6 @@
         args="HiroNX(Robot)0
               $(find hironx_ros_bridge)/models/kawada-hironx.dae
               -ORBInitRef NameService=corbaloc:iiop:localhost:$(arg corbaport)/NameService"
-         time-limit="200" retry="2" />
+         time-limit="400" retry="4" />
 
 </launch>


### PR DESCRIPTION
hot fix for https://github.com/start-jsk/rtmros_hironx/issues/539

On 16.04 (omniorb4-dev 4.1) if we start openhrp-model-loader with <env name="ORBgiopMaxMsgSize" value="2147483648" /> all connection(?) conect respenct giopMaxMsgSize
 But on 18.04 (omniorb4-dev 4.2) wnneed to set ORBgiopMaxMsgSize=2147483648 for each clients

Closes #539